### PR TITLE
fix: Support correct accessibility for generated types

### DIFF
--- a/src/BB84.SourceGenerators/Generators/AbstractionGenerator.cs
+++ b/src/BB84.SourceGenerators/Generators/AbstractionGenerator.cs
@@ -66,7 +66,7 @@ public sealed class AbstractionGenerator : IIncrementalGenerator
 		sb.AppendLine("#nullable enable");
 		sb.AppendLine($"namespace {abstractionNamespace}");
 		sb.AppendLine("{");
-		sb.AppendLine($"  public partial interface {request.AbstractionType.Name}");
+		sb.AppendLine($"  {GetAccessibilityKeyword(request.AbstractionType.DeclaredAccessibility)} partial interface {request.AbstractionType.Name}");
 		sb.AppendLine("  {");
 		foreach (IMethodSymbol methodSymbol in methodSymbols)
 		{
@@ -100,7 +100,7 @@ public sealed class AbstractionGenerator : IIncrementalGenerator
 		}
 		sb.AppendLine($"namespace {implementationNamespace}");
 		sb.AppendLine("{");
-		sb.AppendLine($"  public partial class {request.ImplementationType.Name} : {request.AbstractionType.Name}");
+		sb.AppendLine($"  {GetAccessibilityKeyword(request.ImplementationType.DeclaredAccessibility)} partial class {request.ImplementationType.Name} : {request.AbstractionType.Name}");
 		sb.AppendLine("  {");
 		foreach (IMethodSymbol methodSymbol in methodSymbols)
 		{
@@ -241,4 +241,20 @@ public sealed class AbstractionGenerator : IIncrementalGenerator
 	/// </returns>
 	private static bool IsCandidateClassNode(SyntaxNode node)
 		=> node is ClassDeclarationSyntax classDeclaration && classDeclaration.AttributeLists.Count > 0;
+
+	/// <summary>
+	/// Converts an <see cref="Accessibility"/> value to its corresponding C# keyword.
+	/// </summary>
+	/// <param name="accessibility">The accessibility to convert.</param>
+	/// <returns>The C# keyword string for the given accessibility.</returns>
+	private static string GetAccessibilityKeyword(Accessibility accessibility) => accessibility switch
+	{
+		Accessibility.Public => "public",
+		Accessibility.Internal => "internal",
+		Accessibility.Protected => "protected",
+		Accessibility.ProtectedOrInternal => "protected internal",
+		Accessibility.ProtectedAndInternal => "private protected",
+		Accessibility.Private => "private",
+		_ => "public"
+	};
 }

--- a/tests/BB84.SourceGenerators.Tests/Generators/AbstractionGeneratorTests.cs
+++ b/tests/BB84.SourceGenerators.Tests/Generators/AbstractionGeneratorTests.cs
@@ -23,7 +23,7 @@ public sealed class AbstractionGeneratorTests
 }
 
 [GenerateAbstraction(typeof(File), typeof(IFileProvider), typeof(FileProvider))]
-public partial class FileProvider
+internal partial class FileProvider
 { }
 
 public partial interface IFileProvider


### PR DESCRIPTION
Changes:

- The code generator now emits the correct C# accessibility keyword (`public`, `internal`, `protected`, etc.) for generated interfaces and classes, instead of always using `public`.
- This is implemented via a new `GetAccessibilityKeyword` helper that maps the Accessibility enum to the appropriate keyword, ensuring generated code matches the declared accessibility of the source types.

closes #15 