### PR TITLE
fix: Improve handling of C# parameter modifiers in abstractions

### DIFF
--- a/src/BB84.SourceGenerators/AbstractionGenerator.cs
+++ b/src/BB84.SourceGenerators/AbstractionGenerator.cs
@@ -175,7 +175,7 @@ public sealed class AbstractionGenerator : IIncrementalGenerator
 	/// </returns>
 	private static string CreateMethodUsing(AbstractionRequest request, IMethodSymbol methodSymbol)
 	{
-		IEnumerable<string> parameters = methodSymbol.Parameters.Select(p => p.Name);
+		IEnumerable<string> parameters = methodSymbol.Parameters.Select(p => $"{GetCallSiteModifier(p)}{p.Name}");
 		return $"{request.TargetType}.{methodSymbol.Name}({string.Join(", ", parameters)})";
 	}
 
@@ -190,7 +190,7 @@ public sealed class AbstractionGenerator : IIncrementalGenerator
 	/// </returns>
 	private static string CreateMethodSignature(IMethodSymbol methodSymbol)
 	{
-		IEnumerable<string> parameters = methodSymbol.Parameters.Select(p => $"{p.Type} {p.Name}");
+		IEnumerable<string> parameters = methodSymbol.Parameters.Select(p => $"{GetParameterModifier(p)}{p.Type} {p.Name}");
 		return $"{methodSymbol.ReturnType} {methodSymbol.Name}({string.Join(", ", parameters)})";
 	}
 
@@ -259,8 +259,42 @@ public sealed class AbstractionGenerator : IIncrementalGenerator
 	/// </returns>
 	private static string CreateMethodComment(AbstractionRequest request, IMethodSymbol methodSymbol)
 	{
-		IEnumerable<string> parameters = methodSymbol.Parameters.Select(p => $"{p.Type}".Replace('<', '{').Replace('>', '}'));
+		IEnumerable<string> parameters = methodSymbol.Parameters.Select(p => $"{GetParameterModifier(p)}{p.Type}".Replace('<', '{').Replace('>', '}'));
 		return $"/// <inheritdoc cref=\"{request.TargetType}.{methodSymbol.Name}({string.Join(", ", parameters)})\"/>";
+	}
+
+	/// <summary>
+	/// Gets the C# keyword prefix for a parameter declaration based on its ref kind and params status.
+	/// </summary>
+	/// <param name="parameter">The parameter symbol.</param>
+	/// <returns>The modifier keyword followed by a space, or an empty string if none applies.</returns>
+	private static string GetParameterModifier(IParameterSymbol parameter)
+	{
+		if (parameter.IsParams)
+			return "params ";
+
+		return parameter.RefKind switch
+		{
+			RefKind.Out => "out ",
+			RefKind.Ref => "ref ",
+			RefKind.In => "in ",
+			_ => string.Empty
+		};
+	}
+
+	/// <summary>
+	/// Gets the C# keyword prefix for a call-site argument based on its ref kind.
+	/// </summary>
+	/// <param name="parameter">The parameter symbol.</param>
+	/// <returns>The modifier keyword followed by a space, or an empty string if none applies.</returns>
+	private static string GetCallSiteModifier(IParameterSymbol parameter)
+	{
+		return parameter.RefKind switch
+		{
+			RefKind.Out => "out ",
+			RefKind.Ref => "ref ",
+			_ => string.Empty
+		};
 	}
 
 	/// <summary>

--- a/tests/BB84.SourceGenerators.Tests/Generators/AbstractionGeneratorTests.cs
+++ b/tests/BB84.SourceGenerators.Tests/Generators/AbstractionGeneratorTests.cs
@@ -39,15 +39,26 @@ public sealed class AbstractionGeneratorTests
 	[TestMethod]
 	public void ExcludePropertiesTest()
 	{
-		IDirectoryProvider? provider;
+		IPathProvider? provider;
 
-		provider = new DirectoryProvider();
+		provider = new PathProvider();
 
 		Assert.IsNotNull(provider);
-		Assert.IsInstanceOfType<IDirectoryProvider>(provider);
+		Assert.IsInstanceOfType<IPathProvider>(provider);
 
-		string currentDirectory = provider.GetCurrentDirectory();
-		Assert.IsNotNull(currentDirectory);
+		string randomFileName = provider.GetRandomFileName();
+		Assert.IsNotNull(randomFileName);
+	}
+
+	[TestMethod]
+	public void OutParameterTest()
+	{
+		IOutParamProvider provider = new OutParamProvider();
+
+		bool result = provider.TryParse("42", out int value);
+
+		Assert.IsTrue(result);
+		Assert.AreEqual(42, value);
 	}
 }
 
@@ -65,9 +76,22 @@ internal sealed partial class EnvironmentProvider
 public partial interface IEnvironmentProvider
 { }
 
-[GenerateAbstraction(typeof(Directory), typeof(IDirectoryProvider), typeof(DirectoryProvider), ExcludeProperties = new string[] { "Dummy" })]
-internal sealed partial class DirectoryProvider
+[GenerateAbstraction(typeof(Path), typeof(IPathProvider), typeof(PathProvider), ExcludeProperties = new string[] { nameof(Path.EndsInDirectorySeparator) })]
+internal sealed partial class PathProvider
 { }
 
-public partial interface IDirectoryProvider
+public partial interface IPathProvider
+{ }
+
+public static class OutParamHelper
+{
+	public static bool TryParse(string input, out int result)
+		=> int.TryParse(input, out result);
+}
+
+[GenerateAbstraction(typeof(OutParamHelper), typeof(IOutParamProvider), typeof(OutParamProvider))]
+internal sealed partial class OutParamProvider
+{ }
+
+public partial interface IOutParamProvider
 { }


### PR DESCRIPTION
**Changes:**

- Enhanced abstraction generator to correctly handle ref, out, in, and params modifiers in method signatures, call sites, and XML documentation.
- Added helper methods for modifier insertion.
- Updated and expanded tests to cover methods with out parameters and adjusted test scaffolding to use `PathProvider` and new `OutParam` abstractions.

closes #34