### PR TITLE
feat: Add enum and `[Flags]` enum support to INI generator

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,16 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "06:00"
+    assignees:
+      - "BoBoBaSs84"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "06:00"
+    assignees:
+      - "BoBoBaSs84"

--- a/src/BB84.SourceGenerators/IniFileGenerator.cs
+++ b/src/BB84.SourceGenerators/IniFileGenerator.cs
@@ -69,6 +69,7 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 		sb.AppendLine("#nullable enable");
 		sb.AppendLine("using System;");
 		sb.AppendLine("using System.Globalization;");
+		sb.AppendLine("using System.Linq;");
 		sb.AppendLine("using System.Text;");
 		sb.AppendLine();
 		sb.AppendLine($"namespace {namespaceName}");
@@ -141,7 +142,7 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 				string valueElsePrefix = v > 0 ? "else " : "";
 
 				sb.AppendLine($"          {valueElsePrefix}if (string.Equals(key, \"{value.KeyName}\", StringComparison.{stringComparison}))");
-				sb.AppendLine($"            result.{section.PropertyPath}.{value.PropertyName} = {GetParseExpression(value.TypeName, "value")};");
+				sb.AppendLine($"            result.{section.PropertyPath}.{value.PropertyName} = {GetParseExpression(value, "value")};");
 			}
 
 			sb.AppendLine("        }");
@@ -181,7 +182,7 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 
 			foreach (ValueInfo value in section.Values)
 			{
-				sb.AppendLine($"        sb.AppendLine(\"{value.KeyName}=\" + {GetToStringExpression($"instance.{section.PropertyPath}.{value.PropertyName}", value.TypeName)});");
+				sb.AppendLine($"        sb.AppendLine(\"{value.KeyName}=\" + {GetToStringExpression($"instance.{section.PropertyPath}.{value.PropertyName}", value)});");
 			}
 
 			sb.AppendLine("      }");
@@ -344,10 +345,24 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 				_ => propertySymbol.Type.ToDisplayString()
 			};
 
+			bool isEnum = propertySymbol.Type.TypeKind == TypeKind.Enum;
+			bool isFlagsEnum = false;
+			string? enumFullName = null;
+
+			if (isEnum)
+			{
+				enumFullName = propertySymbol.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+				isFlagsEnum = propertySymbol.Type.GetAttributes()
+					.Any(a => a.AttributeClass?.ToDisplayString() == "System.FlagsAttribute");
+			}
+
 			values.Add(new ValueInfo(
 				PropertyName: propertySymbol.Name,
 				KeyName: keyName,
-				TypeName: typeName
+				TypeName: typeName,
+				IsEnum: isEnum,
+				IsFlagsEnum: isFlagsEnum,
+				EnumFullName: enumFullName
 			));
 		}
 
@@ -369,9 +384,16 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 		return false;
 	}
 
-	private static string GetParseExpression(string typeName, string variableName)
+	private static string GetParseExpression(ValueInfo value, string variableName)
 	{
-		return typeName switch
+		if (value.IsEnum && value.EnumFullName is not null)
+		{
+			return value.IsFlagsEnum
+				? $"({value.EnumFullName}){variableName}.Split(' ').Select(flag => ({value.EnumFullName})Enum.Parse(typeof({value.EnumFullName}), flag)).Aggregate(0, (current, flag) => current | (int)flag)"
+				: $"({value.EnumFullName})Enum.Parse(typeof({value.EnumFullName}), {variableName})";
+		}
+
+		return value.TypeName switch
 		{
 			"string" => variableName,
 			"int" => $"int.Parse({variableName}, CultureInfo.InvariantCulture)",
@@ -385,9 +407,16 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 		};
 	}
 
-	private static string GetToStringExpression(string expression, string typeName)
+	private static string GetToStringExpression(string expression, ValueInfo value)
 	{
-		return typeName switch
+		if (value.IsEnum && value.EnumFullName is not null)
+		{
+			return value.IsFlagsEnum
+				? $"string.Join(\" \", Enum.GetValues(typeof({value.EnumFullName})).Cast<{value.EnumFullName}>().Where(flag => flag != 0 && {expression}.HasFlag(flag)).Select(flag => flag.ToString()))"
+				: $"{expression}.ToString()";
+		}
+
+		return value.TypeName switch
 		{
 			"string" => expression,
 			"bool" => $"{expression}.ToString()",
@@ -489,6 +518,9 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 	private sealed record ValueInfo(
 		string PropertyName,
 		string KeyName,
-		string TypeName
+		string TypeName,
+		bool IsEnum = false,
+		bool IsFlagsEnum = false,
+		string? EnumFullName = null
 	);
 }

--- a/tests/BB84.SourceGenerators.Tests/Generators/IniFileGeneratorTests.cs
+++ b/tests/BB84.SourceGenerators.Tests/Generators/IniFileGeneratorTests.cs
@@ -527,6 +527,85 @@ public sealed class IniFileGeneratorTests
 		Assert.Contains("[Section/SubSection]", result);
 		Assert.DoesNotContain("[Section.SubSection]", result);
 	}
+	[TestMethod]
+	public void ReadShouldHandleEnumValues()
+	{
+		string content = "[App]\r\nLevel=Warning\r\n";
+
+		TestIniFileWithEnums result = TestIniFileWithEnums.Read(content);
+
+		Assert.IsNotNull(result.App);
+		Assert.AreEqual(TestLogLevel.Warning, result.App.Level);
+	}
+
+	[TestMethod]
+	public void WriteShouldHandleEnumValues()
+	{
+		TestIniFileWithEnums instance = new()
+		{
+			App = new TestAppSection { Level = TestLogLevel.Error }
+		};
+
+		string result = TestIniFileWithEnums.Write(instance);
+
+		Assert.Contains("[App]", result);
+		Assert.Contains("Level=Error", result);
+	}
+
+	[TestMethod]
+	public void ReadShouldHandleFlagsEnumValues()
+	{
+		string content = "[App]\r\nPerms=Read Execute\r\n";
+
+		TestIniFileWithFlagsEnum result = TestIniFileWithFlagsEnum.Read(content);
+
+		Assert.IsNotNull(result.App);
+		Assert.AreEqual(TestPermissions.Read | TestPermissions.Execute, result.App.Perms);
+	}
+
+	[TestMethod]
+	public void WriteShouldHandleFlagsEnumValues()
+	{
+		TestIniFileWithFlagsEnum instance = new()
+		{
+			App = new TestFlagsAppSection { Perms = TestPermissions.Read | TestPermissions.Write }
+		};
+
+		string result = TestIniFileWithFlagsEnum.Write(instance);
+
+		Assert.Contains("[App]", result);
+		Assert.Contains("Perms=Read Write", result);
+	}
+
+	[TestMethod]
+	public void ReadThenWriteShouldRoundTripEnumValues()
+	{
+		TestIniFileWithEnums original = new()
+		{
+			App = new TestAppSection { Level = TestLogLevel.Info }
+		};
+
+		string serialized = TestIniFileWithEnums.Write(original);
+		TestIniFileWithEnums deserialized = TestIniFileWithEnums.Read(serialized);
+
+		Assert.IsNotNull(deserialized.App);
+		Assert.AreEqual(original.App.Level, deserialized.App.Level);
+	}
+
+	[TestMethod]
+	public void ReadThenWriteShouldRoundTripFlagsEnumValues()
+	{
+		TestIniFileWithFlagsEnum original = new()
+		{
+			App = new TestFlagsAppSection { Perms = TestPermissions.Read | TestPermissions.Execute }
+		};
+
+		string serialized = TestIniFileWithFlagsEnum.Write(original);
+		TestIniFileWithFlagsEnum deserialized = TestIniFileWithFlagsEnum.Read(serialized);
+
+		Assert.IsNotNull(deserialized.App);
+		Assert.AreEqual(original.App.Perms, deserialized.App.Perms);
+	}
 }
 
 #region Test Types
@@ -667,6 +746,37 @@ internal sealed partial class TestIniFileWithCustomDelimiter
 {
 	[GenerateIniFileSection]
 	public TestSection Section { get; set; } = new TestSection();
+}
+
+public enum TestLogLevel { Debug, Info, Warning, Error }
+
+[Flags]
+public enum TestPermissions { None = 0, Read = 1, Write = 2, Execute = 4 }
+
+[GenerateIniFile]
+internal sealed partial class TestIniFileWithEnums
+{
+	[GenerateIniFileSection]
+	public TestAppSection? App { get; set; }
+}
+
+public class TestAppSection
+{
+	[GenerateIniFileValue]
+	public TestLogLevel Level { get; set; }
+}
+
+[GenerateIniFile]
+internal sealed partial class TestIniFileWithFlagsEnum
+{
+	[GenerateIniFileSection]
+	public TestFlagsAppSection? App { get; set; }
+}
+
+public class TestFlagsAppSection
+{
+	[GenerateIniFileValue]
+	public TestPermissions Perms { get; set; }
 }
 
 #endregion


### PR DESCRIPTION
**Changes:**

- Enhance the INI file code generator to support properties of enum and `[Flags]` enum types.
- The generator now emits code to correctly parse and serialize both regular enums and `[Flags]` enums, including handling multiple flag values as space-separated strings.
- Tests have been added to verify reading, writing, and round-tripping of enum and `[Flags]` enum values.
- No breaking changes to existing functionality.

closes #44 