### PR TITLE
feat: Support serializing XML doc comments as INI comments

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -56,7 +56,6 @@
 	</PropertyGroup>
 
 	<PropertyGroup Condition="$(MSBuildProjectName.EndsWith('Tests'))">
-		<GenerateDocumentationFile>False</GenerateDocumentationFile>
 		<IsPackable>False</IsPackable>
 		<IsTestProject>True</IsTestProject>
 	</PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Generates static `Read` and `Write` methods for classes, enabling compile-time I
 
 **Parameters:**
 
-- `GenerateIniFile` - Marks a class for INI file code generation. The optional `stringComparison` parameter controls how section and key names are compared during deserialization (default: `OrdinalIgnoreCase`). The optional `sectionDelimiter` parameter specifies the delimiter for nested section names (default: `"."`)
+- `GenerateIniFile` - Marks a class for INI file code generation. The optional `stringComparison` parameter controls how section and key names are compared during deserialization (default: `OrdinalIgnoreCase`). The optional `sectionDelimiter` parameter specifies the delimiter for nested section names (default: `"."`). The optional `SerializeComments` property, when set to `true`, includes XML documentation `<summary>` comments from section and value properties as INI comment lines (prefixed with `; `) in the generated `Write` output (default: `false`)
 - `GenerateIniFileSection` - Marks a property as an INI file section. The optional `name` parameter specifies the section name; if omitted, the property name is used. Can also be applied to properties within section types to create nested sections
 - `GenerateIniFileValue` - Marks a property as a key-value pair within an INI section. The optional `name` parameter specifies the key name; if omitted, the property name is used
 
@@ -379,6 +379,7 @@ This produces:
 ```ini
 [Server]
 Host=localhost
+
 [Server.Database]
 Port=5432
 ```
@@ -389,6 +390,48 @@ To use a custom delimiter (e.g., `/`):
 [GenerateIniFile(sectionDelimiter: "/")]
 public partial class Config { ... }
 // Produces: [Server/Database]
+```
+
+**Serializing Comments:**
+
+When `SerializeComments` is set to `true`, XML documentation `<summary>` comments on section and value properties are emitted as INI comment lines (prefixed with `; `) in the `Write` output. The `Read` method automatically skips these comment lines during deserialization:
+
+```csharp
+[GenerateIniFile(SerializeComments = true)]
+public partial class AppConfig
+{
+    /// <summary>
+    /// General application settings
+    /// </summary>
+    [GenerateIniFileSection]
+    public GeneralSection General { get; set; }
+}
+
+public class GeneralSection
+{
+    /// <summary>
+    /// The display name of the application
+    /// </summary>
+    [GenerateIniFileValue]
+    public string AppName { get; set; }
+
+    /// <summary>
+    /// The current version number
+    /// </summary>
+    [GenerateIniFileValue]
+    public int Version { get; set; }
+}
+```
+
+This produces:
+
+```ini
+; General application settings
+[General]
+; The display name of the application
+AppName=MyApp
+; The current version number
+Version=1
 ```
 
 ### 5. Builder Generator

--- a/src/BB84.SourceGenerators/Attributes/GenerateIniFileAttribute.cs
+++ b/src/BB84.SourceGenerators/Attributes/GenerateIniFileAttribute.cs
@@ -30,4 +30,11 @@ internal sealed class GenerateIniFileAttribute(StringComparison stringComparison
 	/// The default value is <c>"."</c>, which means nested sections are represented as <c>[Parent.Child]</c>.
 	/// </summary>
 	public string SectionDelimiter { get; } = sectionDelimiter;
+
+	/// <summary>
+	/// Gets or sets a value indicating whether XML documentation comments on section and value
+	/// properties should be serialized as INI comment lines (prefixed with <c>; </c>) in the
+	/// generated <c>Write</c> method output. The default value is <c>false</c>.
+	/// </summary>
+	public bool SerializeComments { get; set; }
 }

--- a/src/BB84.SourceGenerators/IniFileGenerator.cs
+++ b/src/BB84.SourceGenerators/IniFileGenerator.cs
@@ -60,8 +60,9 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 		string accessibility = GetAccessibility(classDeclaration);
 		string stringComparison = GetStringComparison(classDeclaration, semanticModel);
 		string sectionDelimiter = GetSectionDelimiter(classDeclaration, semanticModel);
+		bool serializeComments = GetSerializeComments(classDeclaration, semanticModel);
 
-		List<SectionInfo> sections = GetSections(classDeclaration, semanticModel, sectionDelimiter);
+		List<SectionInfo> sections = GetSections(classDeclaration, semanticModel, sectionDelimiter, serializeComments);
 
 		StringBuilder sb = new();
 
@@ -76,7 +77,7 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 		sb.AppendLine("{");
 
 		AppendReadMethod(sb, className, accessibility, sections, stringComparison);
-		AppendWriteMethod(sb, className, sections);
+		AppendWriteMethod(sb, className, sections, serializeComments);
 
 		sb.AppendLine("  }");
 		sb.AppendLine("}");
@@ -156,7 +157,7 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 		sb.AppendLine();
 	}
 
-	private static void AppendWriteMethod(StringBuilder sb, string className, List<SectionInfo> sections)
+	private static void AppendWriteMethod(StringBuilder sb, string className, List<SectionInfo> sections, bool serializeComments)
 	{
 		sb.AppendLine("    /// <summary>");
 		sb.AppendLine($"    /// Writes the specified <see cref=\"{className}\"/> instance to an INI file string.");
@@ -178,10 +179,17 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 			string nullCheck = BuildNullCheck($"instance.{section.PropertyPath}");
 			sb.AppendLine($"      if ({nullCheck})");
 			sb.AppendLine("      {");
+
+			if (serializeComments && section.Comment is not null)
+				sb.AppendLine($"        sb.AppendLine(\"; {EscapeString(section.Comment)}\");");
+
 			sb.AppendLine($"        sb.AppendLine(\"[{section.SectionName}]\");");
 
 			foreach (ValueInfo value in section.Values)
 			{
+				if (serializeComments && value.Comment is not null)
+					sb.AppendLine($"        sb.AppendLine(\"; {EscapeString(value.Comment)}\");");
+
 				sb.AppendLine($"        sb.AppendLine(\"{value.KeyName}=\" + {GetToStringExpression($"instance.{section.PropertyPath}.{value.PropertyName}", value)});");
 			}
 
@@ -193,7 +201,7 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 		sb.AppendLine("    }");
 	}
 
-	private static List<SectionInfo> GetSections(ClassDeclarationSyntax classDeclaration, SemanticModel semanticModel, string sectionDelimiter)
+	private static List<SectionInfo> GetSections(ClassDeclarationSyntax classDeclaration, SemanticModel semanticModel, string sectionDelimiter, bool serializeComments)
 	{
 		List<SectionInfo> sections = [];
 		INamedTypeSymbol? classSymbol = semanticModel.GetDeclaredSymbol(classDeclaration);
@@ -232,8 +240,9 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 
 			bool needsInit = !HasInitializer(classDeclaration, propertySymbol.Name);
 			string propertyPath = propertySymbol.Name;
+			string? comment = serializeComments ? GetXmlSummaryComment(propertySymbol) : null;
 
-			List<ValueInfo> values = GetValues(sectionType);
+			List<ValueInfo> values = GetValues(sectionType, serializeComments);
 
 			sections.Add(new SectionInfo(
 				PropertyName: propertySymbol.Name,
@@ -241,16 +250,17 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 				SectionName: sectionName,
 				TypeName: sectionType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
 				NeedsInitialization: needsInit,
-				Values: values
+				Values: values,
+				Comment: comment
 			));
 
-			CollectNestedSections(sections, sectionType, sectionName, propertyPath, sectionDelimiter, 1);
+			CollectNestedSections(sections, sectionType, sectionName, propertyPath, sectionDelimiter, 1, serializeComments);
 		}
 
 		return sections;
 	}
 
-	private static void CollectNestedSections(List<SectionInfo> sections, INamedTypeSymbol parentType, string parentSectionName, string parentPropertyPath, string sectionDelimiter, int depth)
+	private static void CollectNestedSections(List<SectionInfo> sections, INamedTypeSymbol parentType, string parentSectionName, string parentPropertyPath, string sectionDelimiter, int depth, bool serializeComments)
 	{
 		if (depth >= 8)
 			return;
@@ -286,8 +296,9 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 
 			string fullSectionName = $"{parentSectionName}{sectionDelimiter}{sectionName}";
 			string propertyPath = $"{parentPropertyPath}.{propertySymbol.Name}";
+			string? comment = serializeComments ? GetXmlSummaryComment(propertySymbol) : null;
 
-			List<ValueInfo> values = GetValues(sectionType);
+			List<ValueInfo> values = GetValues(sectionType, serializeComments);
 
 			sections.Add(new SectionInfo(
 				PropertyName: propertySymbol.Name,
@@ -295,14 +306,15 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 				SectionName: fullSectionName,
 				TypeName: sectionType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
 				NeedsInitialization: false,
-				Values: values
+				Values: values,
+				Comment: comment
 			));
 
-			CollectNestedSections(sections, sectionType, fullSectionName, propertyPath, sectionDelimiter, depth + 1);
+			CollectNestedSections(sections, sectionType, fullSectionName, propertyPath, sectionDelimiter, depth + 1, serializeComments);
 		}
 	}
 
-	private static List<ValueInfo> GetValues(INamedTypeSymbol sectionType)
+	private static List<ValueInfo> GetValues(INamedTypeSymbol sectionType, bool serializeComments = false)
 	{
 		List<ValueInfo> values = [];
 
@@ -356,13 +368,16 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 					.Any(a => a.AttributeClass?.ToDisplayString() == "System.FlagsAttribute");
 			}
 
+			string? comment = serializeComments ? GetXmlSummaryComment(propertySymbol) : null;
+
 			values.Add(new ValueInfo(
 				PropertyName: propertySymbol.Name,
 				KeyName: keyName,
 				TypeName: typeName,
 				IsEnum: isEnum,
 				IsFlagsEnum: isFlagsEnum,
-				EnumFullName: enumFullName
+				EnumFullName: enumFullName,
+				Comment: comment
 			));
 		}
 
@@ -474,6 +489,84 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 		return ".";
 	}
 
+	private static bool GetSerializeComments(ClassDeclarationSyntax classDeclaration, SemanticModel semanticModel)
+	{
+		foreach (AttributeListSyntax attributeList in classDeclaration.AttributeLists)
+		{
+			foreach (AttributeSyntax attribute in attributeList.Attributes)
+			{
+				string name = attribute.Name.ToString();
+
+				if (name is not "GenerateIniFile" and not "GenerateIniFileAttribute")
+					continue;
+
+				if (attribute.ArgumentList is null)
+					continue;
+
+				foreach (AttributeArgumentSyntax argument in attribute.ArgumentList.Arguments)
+				{
+					if (argument.NameEquals?.Name.Identifier.Text == "SerializeComments")
+						{
+							string expressionText = argument.Expression.ToString();
+							if (expressionText == "true")
+								return true;
+						}
+				}
+			}
+		}
+
+		return false;
+	}
+
+	private static string? GetXmlSummaryComment(ISymbol symbol)
+	{
+		foreach (SyntaxReference syntaxRef in symbol.DeclaringSyntaxReferences)
+		{
+			SyntaxNode node = syntaxRef.GetSyntax();
+
+			if (!node.HasLeadingTrivia)
+				continue;
+
+			foreach (SyntaxTrivia trivia in node.GetLeadingTrivia())
+			{
+				if (trivia.IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia) || trivia.IsKind(SyntaxKind.MultiLineDocumentationCommentTrivia))
+				{
+					SyntaxNode? structure = trivia.GetStructure();
+					if (structure is null)
+						continue;
+
+					foreach (SyntaxNode child in structure.ChildNodes())
+					{
+						if (child is not XmlElementSyntax xmlElement)
+							continue;
+
+						if (xmlElement.StartTag.Name.ToString() != "summary")
+							continue;
+
+						string content = xmlElement.Content.ToString();
+						string[] lines = content.Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries);
+
+						List<string> cleanLines = [];
+						foreach (string line in lines)
+						{
+							string trimmed = line.Trim().TrimStart('/').Trim();
+							if (trimmed.Length > 0)
+								cleanLines.Add(trimmed);
+						}
+
+						if (cleanLines.Count > 0)
+							return string.Join(" ", cleanLines);
+					}
+				}
+			}
+		}
+
+		return null;
+	}
+
+	private static string EscapeString(string value)
+		=> value.Replace("\\", "\\\\").Replace("\"", "\\\"");
+
 	private static string BuildNullCheck(string propertyPath)
 	{
 		string[] segments = propertyPath.Split('.');
@@ -512,7 +605,8 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 		string SectionName,
 		string TypeName,
 		bool NeedsInitialization,
-		List<ValueInfo> Values
+		List<ValueInfo> Values,
+		string? Comment = null
 	);
 
 	private sealed record ValueInfo(
@@ -521,6 +615,7 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 		string TypeName,
 		bool IsEnum = false,
 		bool IsFlagsEnum = false,
-		string? EnumFullName = null
+		string? EnumFullName = null,
+		string? Comment = null
 	);
 }

--- a/src/BB84.SourceGenerators/IniFileGenerator.cs
+++ b/src/BB84.SourceGenerators/IniFileGenerator.cs
@@ -27,6 +27,7 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 	private static readonly string GeneratorAttributeName = typeof(GenerateIniFileAttribute).FullName;
 	private static readonly string SectionAttributeName = typeof(GenerateIniFileSectionAttribute).FullName;
 	private static readonly string ValueAttributeName = typeof(GenerateIniFileValueAttribute).FullName;
+	private static readonly string[] LineBreakSeparators = ["\r\n", "\n"];
 
 	/// <inheritdoc/>
 	public void Initialize(IncrementalGeneratorInitializationContext context)
@@ -60,7 +61,7 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 		string accessibility = GetAccessibility(classDeclaration);
 		string stringComparison = GetStringComparison(classDeclaration, semanticModel);
 		string sectionDelimiter = GetSectionDelimiter(classDeclaration, semanticModel);
-		bool serializeComments = GetSerializeComments(classDeclaration, semanticModel);
+		bool serializeComments = GetSerializeComments(classDeclaration);
 
 		List<SectionInfo> sections = GetSections(classDeclaration, semanticModel, sectionDelimiter, serializeComments);
 
@@ -489,7 +490,7 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 		return ".";
 	}
 
-	private static bool GetSerializeComments(ClassDeclarationSyntax classDeclaration, SemanticModel semanticModel)
+	private static bool GetSerializeComments(ClassDeclarationSyntax classDeclaration)
 	{
 		foreach (AttributeListSyntax attributeList in classDeclaration.AttributeLists)
 		{
@@ -506,11 +507,11 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 				foreach (AttributeArgumentSyntax argument in attribute.ArgumentList.Arguments)
 				{
 					if (argument.NameEquals?.Name.Identifier.Text == "SerializeComments")
-						{
-							string expressionText = argument.Expression.ToString();
-							if (expressionText == "true")
-								return true;
-						}
+					{
+						string expressionText = argument.Expression.ToString();
+						if (expressionText == "true")
+							return true;
+					}
 				}
 			}
 		}
@@ -544,7 +545,7 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 							continue;
 
 						string content = xmlElement.Content.ToString();
-						string[] lines = content.Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries);
+						string[] lines = content.Split(LineBreakSeparators, StringSplitOptions.RemoveEmptyEntries);
 
 						List<string> cleanLines = [];
 						foreach (string line in lines)

--- a/tests/BB84.SourceGenerators.Tests/Generators/IniFileGeneratorTests.cs
+++ b/tests/BB84.SourceGenerators.Tests/Generators/IniFileGeneratorTests.cs
@@ -606,6 +606,66 @@ public sealed class IniFileGeneratorTests
 		Assert.IsNotNull(deserialized.App);
 		Assert.AreEqual(original.App.Perms, deserialized.App.Perms);
 	}
+
+	[TestMethod]
+	public void WriteShouldIncludeCommentsWhenSerializeCommentsIsTrue()
+	{
+		TestIniFileWithComments instance = new()
+		{
+			General = new TestCommentedGeneralSection
+			{
+				AppName = "MyApp",
+				Version = 2
+			}
+		};
+
+		string result = TestIniFileWithComments.Write(instance);
+
+		Assert.Contains("; General application settings", result);
+		Assert.Contains("[General]", result);
+		Assert.Contains("; The display name of the application", result);
+		Assert.Contains("AppName=MyApp", result);
+		Assert.Contains("; The current version number", result);
+		Assert.Contains("Version=2", result);
+	}
+
+	[TestMethod]
+	public void WriteShouldNotIncludeCommentsWhenSerializeCommentsIsFalse()
+	{
+		TestIniFile instance = new()
+		{
+			General = new TestGeneralSection
+			{
+				AppName = "MyApp",
+				Version = 1,
+				Enabled = true
+			}
+		};
+
+		string result = TestIniFile.Write(instance);
+
+		Assert.DoesNotContain("; ", result);
+	}
+
+	[TestMethod]
+	public void ReadShouldSkipCommentLinesFromSerializedOutput()
+	{
+		TestIniFileWithComments instance = new()
+		{
+			General = new TestCommentedGeneralSection
+			{
+				AppName = "TestApp",
+				Version = 5
+			}
+		};
+
+		string serialized = TestIniFileWithComments.Write(instance);
+		TestIniFileWithComments deserialized = TestIniFileWithComments.Read(serialized);
+
+		Assert.IsNotNull(deserialized.General);
+		Assert.AreEqual("TestApp", deserialized.General.AppName);
+		Assert.AreEqual(5, deserialized.General.Version);
+	}
 }
 
 #region Test Types
@@ -777,6 +837,31 @@ public class TestFlagsAppSection
 {
 	[GenerateIniFileValue]
 	public TestPermissions Perms { get; set; }
+}
+
+[GenerateIniFile(SerializeComments = true)]
+internal sealed partial class TestIniFileWithComments
+{
+	/// <summary>
+	/// General application settings
+	/// </summary>
+	[GenerateIniFileSection]
+	public TestCommentedGeneralSection? General { get; set; }
+}
+
+public class TestCommentedGeneralSection
+{
+	/// <summary>
+	/// The display name of the application
+	/// </summary>
+	[GenerateIniFileValue]
+	public string? AppName { get; set; }
+
+	/// <summary>
+	/// The current version number
+	/// </summary>
+	[GenerateIniFileValue]
+	public int Version { get; set; }
 }
 
 #endregion


### PR DESCRIPTION
**Changes:**

- Add `SerializeComments` option to `[GenerateIniFile]` attribute to emit XML <summary> comments as INI comment lines in generated output.
- Update generator to extract and serialize comments for sections and values.
- Extend tests and `README` to cover this feature.

closes #45 