### PR TITLE
fix: Support `nameof` for excluded properties in generators

### DIFF
--- a/src/BB84.SourceGenerators/CloneableGenerator.cs
+++ b/src/BB84.SourceGenerators/CloneableGenerator.cs
@@ -61,7 +61,7 @@ public sealed class CloneableGenerator : IIncrementalGenerator
 		string namespaceName = classDeclaration.GetNamespace();
 		string accessibility = GetAccessibility(classDeclaration);
 
-		HashSet<string> excludedProperties = GetExcludedProperties(classDeclaration);
+		HashSet<string> excludedProperties = GetExcludedProperties(classDeclaration, semanticModel);
 		ImmutableArray<PropertyInfo> properties = GetPublicProperties(classSymbol, excludedProperties);
 
 		StringBuilder sb = new();
@@ -184,7 +184,7 @@ public sealed class CloneableGenerator : IIncrementalGenerator
 		return false;
 	}
 
-	private static HashSet<string> GetExcludedProperties(ClassDeclarationSyntax classDeclaration)
+	private static HashSet<string> GetExcludedProperties(ClassDeclarationSyntax classDeclaration, SemanticModel semanticModel)
 	{
 		HashSet<string> excluded = new(StringComparer.Ordinal);
 
@@ -202,8 +202,10 @@ public sealed class CloneableGenerator : IIncrementalGenerator
 
 				foreach (AttributeArgumentSyntax argument in attribute.ArgumentList.Arguments)
 				{
-					string value = argument.Expression.ToString().Trim('"');
-					excluded.Add(value);
+					Optional<object?> constantValue = semanticModel.GetConstantValue(argument.Expression);
+
+					if (constantValue.HasValue && constantValue.Value is string value)
+						excluded.Add(value);
 				}
 			}
 		}

--- a/src/BB84.SourceGenerators/EqualityGenerator.cs
+++ b/src/BB84.SourceGenerators/EqualityGenerator.cs
@@ -60,7 +60,7 @@ public sealed class EqualityGenerator : IIncrementalGenerator
 		string namespaceName = classDeclaration.GetNamespace();
 		string accessibility = GetAccessibility(classDeclaration);
 
-		HashSet<string> excludedProperties = GetExcludedProperties(classDeclaration);
+		HashSet<string> excludedProperties = GetExcludedProperties(classDeclaration, semanticModel);
 		ImmutableArray<PropertyInfo> properties = GetPublicProperties(classSymbol, excludedProperties);
 
 		StringBuilder sb = new();
@@ -216,7 +216,7 @@ public sealed class EqualityGenerator : IIncrementalGenerator
 		return builder.ToImmutable();
 	}
 
-	private static HashSet<string> GetExcludedProperties(ClassDeclarationSyntax classDeclaration)
+	private static HashSet<string> GetExcludedProperties(ClassDeclarationSyntax classDeclaration, SemanticModel semanticModel)
 	{
 		HashSet<string> excluded = new(StringComparer.Ordinal);
 
@@ -234,8 +234,10 @@ public sealed class EqualityGenerator : IIncrementalGenerator
 
 				foreach (AttributeArgumentSyntax argument in attribute.ArgumentList.Arguments)
 				{
-					string value = argument.Expression.ToString().Trim('"');
-					excluded.Add(value);
+					Optional<object?> constantValue = semanticModel.GetConstantValue(argument.Expression);
+
+					if (constantValue.HasValue && constantValue.Value is string value)
+						excluded.Add(value);
 				}
 			}
 		}

--- a/src/BB84.SourceGenerators/ToStringGenerator.cs
+++ b/src/BB84.SourceGenerators/ToStringGenerator.cs
@@ -58,7 +58,7 @@ public sealed class ToStringGenerator : IIncrementalGenerator
 		string namespaceName = classDeclaration.GetNamespace();
 		string accessibility = GetAccessibility(classDeclaration);
 
-		HashSet<string> excludedProperties = GetExcludedProperties(classDeclaration);
+		HashSet<string> excludedProperties = GetExcludedProperties(classDeclaration, semanticModel);
 		ImmutableArray<string> properties = GetPublicProperties(classSymbol, excludedProperties);
 
 		List<(string Accessibility, string Name)> outerClasses = GetOuterClasses(classDeclaration);
@@ -158,7 +158,7 @@ public sealed class ToStringGenerator : IIncrementalGenerator
 		return builder.ToImmutable();
 	}
 
-	private static HashSet<string> GetExcludedProperties(ClassDeclarationSyntax classDeclaration)
+	private static HashSet<string> GetExcludedProperties(ClassDeclarationSyntax classDeclaration, SemanticModel semanticModel)
 	{
 		HashSet<string> excluded = new(StringComparer.Ordinal);
 
@@ -176,8 +176,10 @@ public sealed class ToStringGenerator : IIncrementalGenerator
 
 				foreach (AttributeArgumentSyntax argument in attribute.ArgumentList.Arguments)
 				{
-					string value = argument.Expression.ToString().Trim('"');
-					excluded.Add(value);
+					Optional<object?> constantValue = semanticModel.GetConstantValue(argument.Expression);
+
+					if (constantValue.HasValue && constantValue.Value is string value)
+						excluded.Add(value);
 				}
 			}
 		}

--- a/tests/BB84.SourceGenerators.Tests/CloneableGeneratorTests.cs
+++ b/tests/BB84.SourceGenerators.Tests/CloneableGeneratorTests.cs
@@ -171,7 +171,7 @@ public partial class CloneableNestedModel
 	public string? Value { get; set; }
 }
 
-[GenerateCloneable("Secret")]
+[GenerateCloneable(nameof(Secret))]
 public partial class CloneableExcludeTestModel
 {
 	public int Id { get; set; }

--- a/tests/BB84.SourceGenerators.Tests/EqualityGeneratorTests.cs
+++ b/tests/BB84.SourceGenerators.Tests/EqualityGeneratorTests.cs
@@ -166,7 +166,7 @@ public partial class EqualityTestModel
 	public bool IsActive { get; set; }
 }
 
-[GenerateEquality("Secret")]
+[GenerateEquality(nameof(Secret))]
 public partial class EqualityExcludeTestModel
 {
 	public int Id { get; set; }

--- a/tests/BB84.SourceGenerators.Tests/GeneratorDriverTests.cs
+++ b/tests/BB84.SourceGenerators.Tests/GeneratorDriverTests.cs
@@ -58,10 +58,10 @@ using BB84.SourceGenerators.Attributes;
 
 namespace TestNamespace
 {
-  [GenerateToString]
-  public partial class EmptyModel
-  {
-  }
+	[GenerateToString]
+	public partial class EmptyModel
+	{
+	}
 }";
 
 		(ImmutableArray<Diagnostic> diagnostics, string[] generatedSources) = RunGenerator<ToStringGenerator>(source);
@@ -70,6 +70,35 @@ namespace TestNamespace
 		Assert.IsNotEmpty(generatedSources);
 		string generated = generatedSources.First(s => s.Contains("override string ToString()"));
 		Assert.Contains("EmptyModel", generated);
+	}
+
+	[TestMethod]
+	public void ToStringGeneratorShouldExcludeNameofProperties()
+	{
+		string source = @"
+using BB84.SourceGenerators.Attributes;
+
+namespace TestNamespace
+{
+	[GenerateToString(""Secret"", nameof(ExcludeModel.Internal))]
+	public partial class ExcludeModel
+	{
+		public int Id { get; set; }
+		public string Name { get; set; }
+		public string Secret { get; set; }
+		public string Internal { get; set; }
+	}
+}";
+
+		(ImmutableArray<Diagnostic> diagnostics, string[] generatedSources) = RunGenerator<ToStringGenerator>(source);
+
+		Assert.IsEmpty(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
+		Assert.IsNotEmpty(generatedSources);
+		string generated = generatedSources.First(s => s.Contains("override string ToString()"));
+		Assert.Contains("Id", generated);
+		Assert.Contains("Name", generated);
+		Assert.DoesNotContain("Secret", generated);
+		Assert.DoesNotContain("Internal", generated);
 	}
 
 	[TestMethod]
@@ -115,6 +144,33 @@ namespace TestNamespace
 
 		Assert.IsEmpty(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
 		Assert.IsNotEmpty(generatedSources);
+	}
+
+	[TestMethod]
+	public void EqualityGeneratorShouldExcludeNameofProperties()
+	{
+		string source = @"
+using BB84.SourceGenerators.Attributes;
+
+namespace TestNamespace
+{
+	[GenerateEquality(nameof(EqExModel.Secret))]
+	public partial class EqExModel
+	{
+		public int Id { get; set; }
+		public string Name { get; set; }
+		public string Secret { get; set; }
+	}
+}";
+
+		(ImmutableArray<Diagnostic> diagnostics, string[] generatedSources) = RunGenerator<EqualityGenerator>(source);
+
+		Assert.IsEmpty(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
+		Assert.IsNotEmpty(generatedSources);
+		string generated = generatedSources.First(s => s.Contains("partial class EqExModel"));
+		Assert.Contains("Id", generated);
+		Assert.Contains("Name", generated);
+		Assert.DoesNotContain("Secret", generated);
 	}
 
 	[TestMethod]
@@ -231,6 +287,33 @@ namespace TestNamespace
 		string generated = generatedSources.First(s => s.Contains("DeepClone"));
 		Assert.Contains("Clone()", generated);
 		Assert.Contains("DeepClone()", generated);
+	}
+
+	[TestMethod]
+	public void CloneableGeneratorShouldExcludeNameofProperties()
+	{
+		string source = @"
+using BB84.SourceGenerators.Attributes;
+
+namespace TestNamespace
+{
+	[GenerateCloneable(nameof(CloneExModel.Secret))]
+	public partial class CloneExModel
+	{
+		public int Id { get; set; }
+		public string Name { get; set; }
+		public string Secret { get; set; }
+	}
+}";
+
+		(ImmutableArray<Diagnostic> diagnostics, string[] generatedSources) = RunGenerator<CloneableGenerator>(source);
+
+		Assert.IsEmpty(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
+		Assert.IsNotEmpty(generatedSources);
+		string generated = generatedSources.First(s => s.Contains("partial class CloneExModel"));
+		Assert.Contains("Id", generated);
+		Assert.Contains("Name", generated);
+		Assert.DoesNotContain("Secret", generated);
 	}
 
 	[TestMethod]

--- a/tests/BB84.SourceGenerators.Tests/ToStringGeneratorTests.cs
+++ b/tests/BB84.SourceGenerators.Tests/ToStringGeneratorTests.cs
@@ -135,7 +135,7 @@ public partial class ToStringTestModel
 	public bool IsActive { get; set; }
 }
 
-[GenerateToString("Secret", "Internal")]
+[GenerateToString("Secret", nameof(Internal))]
 public partial class ToStringExcludeTestModel
 {
 	public int Id { get; set; }


### PR DESCRIPTION
**Changes:**

- Generators now support `nameof` expressions for excluded properties, improving refactor safety and reliability.
- The exclusion logic uses semantic analysis to resolve both string literals and nameof values.
- Tests and test models updated to use nameof; new tests verify correct behavior.
- This change reduces errors from typos and eases maintenance.

closes #60 