### PR TITLE
fix: Enforce `[GenerateValidator]` usage rules and inheritance

### DIFF
--- a/README.md
+++ b/README.md
@@ -618,6 +618,11 @@ Generates a `Validate()` method for classes, scanning properties for data annota
 - `[MaxLength(length)]` - Validates maximum length of a string or collection
 - `[RegularExpression(pattern)]` - Validates that a string matches a regex pattern
 
+**Constraints:**
+
+- The attribute cannot be applied to abstract classes. A compile-time error (`BB84SG0001`) will be emitted if used on an abstract class.
+- When a class inherits from a base class, the generated validator includes validation for all public properties from the entire inheritance hierarchy.
+
 #### Example
 
 ```csharp

--- a/src/BB84.SourceGenerators/Analyzers/DiagnosticDescriptors.cs
+++ b/src/BB84.SourceGenerators/Analyzers/DiagnosticDescriptors.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.CodeAnalysis;
+
+namespace BB84.SourceGenerators.Analyzers;
+
+/// <summary>
+/// Represents a collection of <see cref="DiagnosticDescriptor"/> instances used by the source generator analyzers
+/// </summary>
+internal static class DiagnosticDescriptors
+{
+	/// <summary>
+	/// Represents a diagnostic error indicating that the [GenerateValidator] attribute has been applied to
+	/// an abstract class, which is not supported.
+	/// </summary>
+	internal static readonly DiagnosticDescriptor AbstractClassDiagnostic = new(
+		id: "BB84SG0001",
+		title: "GenerateValidator cannot be applied to abstract classes",
+		messageFormat: "The [GenerateValidator] attribute cannot be applied to abstract class '{0}'",
+		category: "BB84.SourceGenerators",
+		defaultSeverity: DiagnosticSeverity.Error,
+		isEnabledByDefault: true);
+}

--- a/src/BB84.SourceGenerators/BB84.SourceGenerators.csproj
+++ b/src/BB84.SourceGenerators/BB84.SourceGenerators.csproj
@@ -9,7 +9,7 @@
 		<IncludeBuildOutput>False</IncludeBuildOutput>
 		<IsRoslynComponent>True</IsRoslynComponent>
 		<!-- Suppresses the expected warning about lib/ TFM without a matching dependency group (we intentionally suppress dependencies) -->
-		<NoWarn>$(NoWarn);NU5128</NoWarn>
+		<NoWarn>$(NoWarn);NU5128;RS2008</NoWarn>
 		<!-- Prevents Roslyn (Microsoft.CodeAnalysis.CSharp) and other dependencies from being added as NuGet dependencies — consumers don't need them -->
 		<SuppressDependenciesWhenPacking>True</SuppressDependenciesWhenPacking>
 		<TargetFramework>netstandard2.0</TargetFramework>

--- a/src/BB84.SourceGenerators/ValidatorGenerator.cs
+++ b/src/BB84.SourceGenerators/ValidatorGenerator.cs
@@ -6,6 +6,7 @@
 using System.Collections.Immutable;
 using System.Text;
 
+using BB84.SourceGenerators.Analyzers;
 using BB84.SourceGenerators.Attributes;
 using BB84.SourceGenerators.Extensions;
 
@@ -63,6 +64,13 @@ public sealed class ValidatorGenerator : IIncrementalGenerator
 		INamedTypeSymbol? classSymbol = semanticModel.GetDeclaredSymbol(classDeclaration);
 		if (classSymbol is null)
 			return;
+
+		if (classSymbol.IsAbstract)
+		{
+			Diagnostic diagnostic = Diagnostic.Create(DiagnosticDescriptors.AbstractClassDiagnostic, classDeclaration.Identifier.GetLocation(), classSymbol.Name);
+			context.ReportDiagnostic(diagnostic);
+			return;
+		}
 
 		string className = classSymbol.Name;
 		string namespaceName = classDeclaration.GetNamespace();
@@ -271,8 +279,21 @@ public sealed class ValidatorGenerator : IIncrementalGenerator
 	private static ImmutableArray<PropertyValidationInfo> GetValidatedProperties(INamedTypeSymbol classSymbol)
 	{
 		ImmutableArray<PropertyValidationInfo>.Builder builder = ImmutableArray.CreateBuilder<PropertyValidationInfo>();
+		HashSet<string> seen = [];
 
-		foreach (ISymbol member in classSymbol.GetMembers())
+		INamedTypeSymbol? currentType = classSymbol;
+		while (currentType is not null && currentType.SpecialType != SpecialType.System_Object)
+		{
+			CollectValidatedProperties(currentType, builder, seen);
+			currentType = currentType.BaseType;
+		}
+
+		return builder.ToImmutable();
+	}
+
+	private static void CollectValidatedProperties(INamedTypeSymbol typeSymbol, ImmutableArray<PropertyValidationInfo>.Builder builder, HashSet<string> seen)
+	{
+		foreach (ISymbol member in typeSymbol.GetMembers())
 		{
 			if (member is not IPropertySymbol propertySymbol)
 				continue;
@@ -281,6 +302,9 @@ public sealed class ValidatorGenerator : IIncrementalGenerator
 				continue;
 
 			if (propertySymbol.IsStatic || propertySymbol.GetMethod is null)
+				continue;
+
+			if (!seen.Add(propertySymbol.Name))
 				continue;
 
 			ImmutableArray<ValidationRule>.Builder rules = ImmutableArray.CreateBuilder<ValidationRule>();
@@ -315,8 +339,6 @@ public sealed class ValidatorGenerator : IIncrementalGenerator
 				builder.Add(new PropertyValidationInfo(propertySymbol.Name, typeName, isCollection, isArray, rules.ToImmutable()));
 			}
 		}
-
-		return builder.ToImmutable();
 	}
 
 	private static ValidationRule ParseRequiredAttribute(AttributeData attribute)

--- a/tests/BB84.SourceGenerators.Tests/GeneratorDriverTests.cs
+++ b/tests/BB84.SourceGenerators.Tests/GeneratorDriverTests.cs
@@ -253,16 +253,70 @@ using BB84.SourceGenerators.Attributes;
 
 namespace TestNamespace
 {
-  [GenerateValidator]
-  public partial class EmptyValModel
-  {
-  }
+	[GenerateValidator]
+	public partial class EmptyValModel
+	{
+	}
 }";
 
 		(ImmutableArray<Diagnostic> diagnostics, string[] generatedSources) = RunGenerator<ValidatorGenerator>(source);
 
 		Assert.IsEmpty(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
 		Assert.IsNotEmpty(generatedSources);
+	}
+
+	[TestMethod]
+	public void ValidatorGeneratorAbstractClassShouldReportDiagnostic()
+	{
+		string source = @"
+using System.ComponentModel.DataAnnotations;
+using BB84.SourceGenerators.Attributes;
+
+namespace TestNamespace
+{
+	[GenerateValidator]
+	public abstract partial class AbstractModel
+	{
+		[Range(1, int.MaxValue)]
+		public int Id { get; set; }
+	}
+}";
+
+		(ImmutableArray<Diagnostic> diagnostics, string[] generatedSources) = RunGenerator<ValidatorGenerator>(source);
+
+		Assert.IsNotEmpty(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error && d.Id == "BB84SG0001"));
+	}
+
+	[TestMethod]
+	public void ValidatorGeneratorShouldIncludeInheritedProperties()
+	{
+		string source = @"
+using System.ComponentModel.DataAnnotations;
+using BB84.SourceGenerators.Attributes;
+
+namespace TestNamespace
+{
+	public abstract class AbstractModel
+	{
+		[Range(1, int.MaxValue)]
+		public int Id { get; set; }
+	}
+
+	[GenerateValidator]
+	public partial class ConcreteModel : AbstractModel
+	{
+		[Required]
+		public string Name { get; set; }
+	}
+}";
+
+		(ImmutableArray<Diagnostic> diagnostics, string[] generatedSources) = RunGenerator<ValidatorGenerator>(source);
+
+		Assert.IsEmpty(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
+		Assert.IsNotEmpty(generatedSources);
+		string generated = generatedSources.First(s => s.Contains("partial class ConcreteModel"));
+		Assert.Contains("Name", generated);
+		Assert.Contains("Id", generated);
 	}
 
 	[TestMethod]

--- a/tests/BB84.SourceGenerators.Tests/ValidatorGeneratorTests.cs
+++ b/tests/BB84.SourceGenerators.Tests/ValidatorGeneratorTests.cs
@@ -272,7 +272,7 @@ public sealed class ValidatorGeneratorTests
 	{
 		ValidatorCollectionRangeTestModel model = new()
 		{
-			Scores = Enumerable.Range(1, 101).ToArray()
+			Scores = [.. Enumerable.Range(1, 101)]
 		};
 
 		Dictionary<string, List<string>> errors = model.Validate();
@@ -325,7 +325,7 @@ public sealed class ValidatorGeneratorTests
 	{
 		ValidatorListRangeTestModel model = new()
 		{
-			Values = Enumerable.Range(1, 11).ToList()
+			Values = [.. Enumerable.Range(1, 11)]
 		};
 
 		Dictionary<string, List<string>> errors = model.Validate();
@@ -352,7 +352,7 @@ public sealed class ValidatorGeneratorTests
 	{
 		ValidatorStringCollectionRangeTestModel model = new()
 		{
-			Tags = Enumerable.Range(1, 11).Select(i => i.ToString(System.Globalization.CultureInfo.InvariantCulture)).ToArray()
+			Tags = [.. Enumerable.Range(1, 11).Select(i => i.ToString(System.Globalization.CultureInfo.InvariantCulture))]
 		};
 
 		Dictionary<string, List<string>> errors = model.Validate();


### PR DESCRIPTION
**Changes:**

- Emit compile-time error (BB84SG0001) if `[GenerateValidator]` is applied to abstract classes; add diagnostic definition and enforcement.
- Enhance validator generation to include all public properties from base classes (full inheritance hierarchy).
- Update `README` to document new constraints and behavior.
- Add/expand unit tests for abstract class diagnostics and inherited property validation.
- Modernize test code with collection expressions.

closes #61 