### PR TITLE
Refactor: add `GeneratorHelpers` and deduplicate generators

### DIFF
--- a/src/BB84.SourceGenerators/AssemblyInformationGenerator.cs
+++ b/src/BB84.SourceGenerators/AssemblyInformationGenerator.cs
@@ -7,6 +7,7 @@ using System.Text;
 
 using BB84.SourceGenerators.Attributes;
 using BB84.SourceGenerators.Extensions;
+using BB84.SourceGenerators.Helpers;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -46,14 +47,11 @@ public sealed class AssemblyInformationGenerator : IIncrementalGenerator
 				.ForAttributeWithMetadataName(
 					fullyQualifiedMetadataName: GeneratorAttributeName,
 					predicate: static (node, _) => node is ClassDeclarationSyntax,
-					transform: static (ctx, _) => Transform(ctx))
+					transform: static (ctx, _) => GeneratorHelpers.TransformClassSyntax(ctx))
 				.Where(static result => result is not null);
 
 		context.RegisterSourceOutput(provider, Execute);
 	}
-
-	private static (ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)? Transform(GeneratorAttributeSyntaxContext context)
-		=> context.TargetNode is not ClassDeclarationSyntax classSyntax ? null : ((ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)?)(classSyntax, context.SemanticModel);
 
 	private void Execute(SourceProductionContext context, (ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)? input)
 	{
@@ -69,11 +67,11 @@ public sealed class AssemblyInformationGenerator : IIncrementalGenerator
 
 		string className = classSymbol.Name;
 		string namespaceName = classDeclaration.GetNamespace();
-		string accessibility = GetAccessibility(classDeclaration);
+		string accessibility = GeneratorHelpers.GetAccessibility(classDeclaration);
 
 		Dictionary<string, string> assemblyValues = GetAssemblyAttributeValues(semanticModel.Compilation);
 
-		List<(string Accessibility, string Name)> outerClasses = GetOuterClasses(classDeclaration);
+		List<(string Accessibility, string Name)> outerClasses = GeneratorHelpers.GetOuterClasses(classDeclaration);
 
 		StringBuilder sb = new();
 
@@ -153,33 +151,5 @@ public sealed class AssemblyInformationGenerator : IIncrementalGenerator
 		}
 
 		return values;
-	}
-
-	private static string GetAccessibility(ClassDeclarationSyntax classDeclaration)
-	{
-		foreach (SyntaxToken modifier in classDeclaration.Modifiers)
-		{
-			if (modifier.IsKind(SyntaxKind.PublicKeyword))
-				return "public";
-			if (modifier.IsKind(SyntaxKind.InternalKeyword))
-				return "internal";
-		}
-
-		return "internal";
-	}
-
-	private static List<(string Accessibility, string Name)> GetOuterClasses(ClassDeclarationSyntax classDeclaration)
-	{
-		List<(string Accessibility, string Name)> outerClasses = [];
-		SyntaxNode? parent = classDeclaration.Parent;
-
-		while (parent is ClassDeclarationSyntax outerClass)
-		{
-			outerClasses.Add((GetAccessibility(outerClass), outerClass.Identifier.Text));
-			parent = outerClass.Parent;
-		}
-
-		outerClasses.Reverse();
-		return outerClasses;
 	}
 }

--- a/src/BB84.SourceGenerators/BuilderGenerator.cs
+++ b/src/BB84.SourceGenerators/BuilderGenerator.cs
@@ -8,6 +8,7 @@ using System.Text;
 
 using BB84.SourceGenerators.Attributes;
 using BB84.SourceGenerators.Extensions;
+using BB84.SourceGenerators.Helpers;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -33,18 +34,10 @@ public sealed class BuilderGenerator : IIncrementalGenerator
 				.ForAttributeWithMetadataName(
 					fullyQualifiedMetadataName: GeneratorAttributeName,
 					predicate: static (node, _) => node is ClassDeclarationSyntax,
-					transform: static (ctx, _) => Transform(ctx))
+					transform: static (ctx, _) => GeneratorHelpers.TransformClassSyntax(ctx))
 				.Where(static result => result is not null);
 
 		context.RegisterSourceOutput(provider, Execute);
-	}
-
-	private static (ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)? Transform(GeneratorAttributeSyntaxContext context)
-	{
-		if (context.TargetNode is not ClassDeclarationSyntax classSyntax)
-			return null;
-
-		return (classSyntax, context.SemanticModel);
 	}
 
 	private void Execute(SourceProductionContext context, (ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)? input)
@@ -61,7 +54,7 @@ public sealed class BuilderGenerator : IIncrementalGenerator
 
 		string className = classSymbol.Name;
 		string namespaceName = classDeclaration.GetNamespace();
-		string accessibility = GetAccessibility(classDeclaration);
+		string accessibility = GeneratorHelpers.GetAccessibility(classDeclaration);
 		string builderClassName = $"{className}Builder";
 
 		ImmutableArray<PropertyInfo> properties = GetSettableProperties(classSymbol);
@@ -172,32 +165,11 @@ public sealed class BuilderGenerator : IIncrementalGenerator
 		return builder.ToImmutable();
 	}
 
-	private static string GetAccessibility(ClassDeclarationSyntax classDeclaration)
+	private readonly struct PropertyInfo(string name, string typeName, bool isReferenceType, bool isNullable)
 	{
-		foreach (SyntaxToken modifier in classDeclaration.Modifiers)
-		{
-			if (modifier.IsKind(SyntaxKind.PublicKeyword))
-				return "public";
-			if (modifier.IsKind(SyntaxKind.InternalKeyword))
-				return "internal";
-		}
-
-		return "internal";
-	}
-
-	private readonly struct PropertyInfo
-	{
-		public PropertyInfo(string name, string typeName, bool isReferenceType, bool isNullable)
-		{
-			Name = name;
-			TypeName = typeName;
-			IsReferenceType = isReferenceType;
-			IsNullable = isNullable;
-		}
-
-		public string Name { get; }
-		public string TypeName { get; }
-		public bool IsReferenceType { get; }
-		public bool IsNullable { get; }
+		public string Name { get; } = name;
+		public string TypeName { get; } = typeName;
+		public bool IsReferenceType { get; } = isReferenceType;
+		public bool IsNullable { get; } = isNullable;
 	}
 }

--- a/src/BB84.SourceGenerators/CloneableGenerator.cs
+++ b/src/BB84.SourceGenerators/CloneableGenerator.cs
@@ -8,6 +8,7 @@ using System.Text;
 
 using BB84.SourceGenerators.Attributes;
 using BB84.SourceGenerators.Extensions;
+using BB84.SourceGenerators.Helpers;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -36,14 +37,11 @@ public sealed class CloneableGenerator : IIncrementalGenerator
 				.ForAttributeWithMetadataName(
 					fullyQualifiedMetadataName: GeneratorAttributeName,
 					predicate: static (node, _) => node is ClassDeclarationSyntax,
-					transform: static (ctx, _) => Transform(ctx))
+					transform: static (ctx, _) => GeneratorHelpers.TransformClassSyntax(ctx))
 				.Where(static result => result is not null);
 
 		context.RegisterSourceOutput(provider, Execute);
 	}
-
-	private static (ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)? Transform(GeneratorAttributeSyntaxContext context)
-		=> context.TargetNode is not ClassDeclarationSyntax classSyntax ? null : ((ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)?)(classSyntax, context.SemanticModel);
 
 	private void Execute(SourceProductionContext context, (ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)? input)
 	{
@@ -59,9 +57,9 @@ public sealed class CloneableGenerator : IIncrementalGenerator
 
 		string className = classSymbol.Name;
 		string namespaceName = classDeclaration.GetNamespace();
-		string accessibility = GetAccessibility(classDeclaration);
+		string accessibility = GeneratorHelpers.GetAccessibility(classDeclaration);
 
-		HashSet<string> excludedProperties = GetExcludedProperties(classDeclaration, semanticModel);
+		HashSet<string> excludedProperties = GeneratorHelpers.GetExcludedProperties(classDeclaration, semanticModel, "GenerateCloneable", "GenerateCloneableAttribute");
 		ImmutableArray<PropertyInfo> properties = GetPublicProperties(classSymbol, excludedProperties);
 
 		StringBuilder sb = new();
@@ -182,48 +180,6 @@ public sealed class CloneableGenerator : IIncrementalGenerator
 		}
 
 		return false;
-	}
-
-	private static HashSet<string> GetExcludedProperties(ClassDeclarationSyntax classDeclaration, SemanticModel semanticModel)
-	{
-		HashSet<string> excluded = new(StringComparer.Ordinal);
-
-		foreach (AttributeListSyntax attributeList in classDeclaration.AttributeLists)
-		{
-			foreach (AttributeSyntax attribute in attributeList.Attributes)
-			{
-				string name = attribute.Name.ToString();
-
-				if (name is not "GenerateCloneable" and not "GenerateCloneableAttribute")
-					continue;
-
-				if (attribute.ArgumentList is null)
-					continue;
-
-				foreach (AttributeArgumentSyntax argument in attribute.ArgumentList.Arguments)
-				{
-					Optional<object?> constantValue = semanticModel.GetConstantValue(argument.Expression);
-
-					if (constantValue.HasValue && constantValue.Value is string value)
-						excluded.Add(value);
-				}
-			}
-		}
-
-		return excluded;
-	}
-
-	private static string GetAccessibility(ClassDeclarationSyntax classDeclaration)
-	{
-		foreach (SyntaxToken modifier in classDeclaration.Modifiers)
-		{
-			if (modifier.IsKind(SyntaxKind.PublicKeyword))
-				return "public";
-			if (modifier.IsKind(SyntaxKind.InternalKeyword))
-				return "internal";
-		}
-
-		return "internal";
 	}
 
 	private readonly struct PropertyInfo(string name, bool isCloneable)

--- a/src/BB84.SourceGenerators/EqualityGenerator.cs
+++ b/src/BB84.SourceGenerators/EqualityGenerator.cs
@@ -8,6 +8,7 @@ using System.Text;
 
 using BB84.SourceGenerators.Attributes;
 using BB84.SourceGenerators.Extensions;
+using BB84.SourceGenerators.Helpers;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -35,14 +36,11 @@ public sealed class EqualityGenerator : IIncrementalGenerator
 				.ForAttributeWithMetadataName(
 					fullyQualifiedMetadataName: GeneratorAttributeName,
 					predicate: static (node, _) => node is ClassDeclarationSyntax,
-					transform: static (ctx, _) => Transform(ctx))
+					transform: static (ctx, _) => GeneratorHelpers.TransformClassSyntax(ctx))
 				.Where(static result => result is not null);
 
 		context.RegisterSourceOutput(provider, Execute);
 	}
-
-	private static (ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)? Transform(GeneratorAttributeSyntaxContext context)
-		=> context.TargetNode is not ClassDeclarationSyntax classSyntax ? null : ((ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)?)(classSyntax, context.SemanticModel);
 
 	private void Execute(SourceProductionContext context, (ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)? input)
 	{
@@ -58,9 +56,9 @@ public sealed class EqualityGenerator : IIncrementalGenerator
 
 		string className = classSymbol.Name;
 		string namespaceName = classDeclaration.GetNamespace();
-		string accessibility = GetAccessibility(classDeclaration);
+		string accessibility = GeneratorHelpers.GetAccessibility(classDeclaration);
 
-		HashSet<string> excludedProperties = GetExcludedProperties(classDeclaration, semanticModel);
+		HashSet<string> excludedProperties = GeneratorHelpers.GetExcludedProperties(classDeclaration, semanticModel, "GenerateEquality", "GenerateEqualityAttribute");
 		ImmutableArray<PropertyInfo> properties = GetPublicProperties(classSymbol, excludedProperties);
 
 		StringBuilder sb = new();
@@ -214,48 +212,6 @@ public sealed class EqualityGenerator : IIncrementalGenerator
 		}
 
 		return builder.ToImmutable();
-	}
-
-	private static HashSet<string> GetExcludedProperties(ClassDeclarationSyntax classDeclaration, SemanticModel semanticModel)
-	{
-		HashSet<string> excluded = new(StringComparer.Ordinal);
-
-		foreach (AttributeListSyntax attributeList in classDeclaration.AttributeLists)
-		{
-			foreach (AttributeSyntax attribute in attributeList.Attributes)
-			{
-				string name = attribute.Name.ToString();
-
-				if (name is not "GenerateEquality" and not "GenerateEqualityAttribute")
-					continue;
-
-				if (attribute.ArgumentList is null)
-					continue;
-
-				foreach (AttributeArgumentSyntax argument in attribute.ArgumentList.Arguments)
-				{
-					Optional<object?> constantValue = semanticModel.GetConstantValue(argument.Expression);
-
-					if (constantValue.HasValue && constantValue.Value is string value)
-						excluded.Add(value);
-				}
-			}
-		}
-
-		return excluded;
-	}
-
-	private static string GetAccessibility(ClassDeclarationSyntax classDeclaration)
-	{
-		foreach (SyntaxToken modifier in classDeclaration.Modifiers)
-		{
-			if (modifier.IsKind(SyntaxKind.PublicKeyword))
-				return "public";
-			if (modifier.IsKind(SyntaxKind.InternalKeyword))
-				return "internal";
-		}
-
-		return "internal";
 	}
 
 	private readonly struct PropertyInfo(string name, bool isValueType)

--- a/src/BB84.SourceGenerators/Helpers/DataAnnotationNames.cs
+++ b/src/BB84.SourceGenerators/Helpers/DataAnnotationNames.cs
@@ -1,0 +1,19 @@
+// Copyright: 2026 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+namespace BB84.SourceGenerators.Helpers;
+
+/// <summary>
+/// Contains fully qualified names of data annotation attributes used by the <see cref="ValidatorGenerator"/>.
+/// </summary>
+internal static class DataAnnotationNames
+{
+	internal const string Required = "System.ComponentModel.DataAnnotations.RequiredAttribute";
+	internal const string Range = "System.ComponentModel.DataAnnotations.RangeAttribute";
+	internal const string StringLength = "System.ComponentModel.DataAnnotations.StringLengthAttribute";
+	internal const string MinLength = "System.ComponentModel.DataAnnotations.MinLengthAttribute";
+	internal const string MaxLength = "System.ComponentModel.DataAnnotations.MaxLengthAttribute";
+	internal const string RegularExpression = "System.ComponentModel.DataAnnotations.RegularExpressionAttribute";
+}

--- a/src/BB84.SourceGenerators/Helpers/GeneratorHelpers.cs
+++ b/src/BB84.SourceGenerators/Helpers/GeneratorHelpers.cs
@@ -1,0 +1,119 @@
+// Copyright: 2026 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace BB84.SourceGenerators.Helpers;
+
+/// <summary>
+/// Provides shared helper methods used across multiple source generators.
+/// </summary>
+internal static class GeneratorHelpers
+{
+	/// <summary>
+	/// Gets the accessibility keyword for a class declaration.
+	/// </summary>
+	/// <param name="classDeclaration">The class declaration syntax.</param>
+	/// <returns>The accessibility keyword string.</returns>
+	internal static string GetAccessibility(ClassDeclarationSyntax classDeclaration)
+	{
+		foreach (SyntaxToken modifier in classDeclaration.Modifiers)
+		{
+			if (modifier.IsKind(SyntaxKind.PublicKeyword))
+				return "public";
+			if (modifier.IsKind(SyntaxKind.InternalKeyword))
+				return "internal";
+			if (modifier.IsKind(SyntaxKind.ProtectedKeyword))
+				return "protected";
+			if (modifier.IsKind(SyntaxKind.PrivateKeyword))
+				return "private";
+		}
+
+		return "internal";
+	}
+
+	/// <summary>
+	/// Gets the list of outer (nesting) classes for a given class declaration.
+	/// </summary>
+	/// <param name="classDeclaration">The class declaration syntax.</param>
+	/// <returns>A list of tuples containing the accessibility and name of each outer class, from outermost to innermost.</returns>
+	internal static List<(string Accessibility, string Name)> GetOuterClasses(ClassDeclarationSyntax classDeclaration)
+	{
+		List<(string Accessibility, string Name)> outerClasses = [];
+		SyntaxNode? parent = classDeclaration.Parent;
+
+		while (parent is ClassDeclarationSyntax outerClass)
+		{
+			outerClasses.Add((GetAccessibility(outerClass), outerClass.Identifier.Text));
+			parent = outerClass.Parent;
+		}
+
+		outerClasses.Reverse();
+		return outerClasses;
+	}
+
+	/// <summary>
+	/// Gets the set of excluded property names from an attribute's constructor arguments.
+	/// </summary>
+	/// <param name="classDeclaration">The class declaration syntax.</param>
+	/// <param name="semanticModel">The semantic model.</param>
+	/// <param name="attributeShortName">The short name of the attribute (e.g., "GenerateToString").</param>
+	/// <param name="attributeFullName">The full name of the attribute (e.g., "GenerateToStringAttribute").</param>
+	/// <returns>A set of excluded property names.</returns>
+	internal static HashSet<string> GetExcludedProperties(ClassDeclarationSyntax classDeclaration, SemanticModel semanticModel, string attributeShortName, string attributeFullName)
+	{
+		HashSet<string> excluded = new(StringComparer.Ordinal);
+
+		foreach (AttributeListSyntax attributeList in classDeclaration.AttributeLists)
+		{
+			foreach (AttributeSyntax attribute in attributeList.Attributes)
+			{
+				string name = attribute.Name.ToString();
+
+				if (name != attributeShortName && name != attributeFullName)
+					continue;
+
+				if (attribute.ArgumentList is null)
+					continue;
+
+				foreach (AttributeArgumentSyntax argument in attribute.ArgumentList.Arguments)
+				{
+					Optional<object?> constantValue = semanticModel.GetConstantValue(argument.Expression);
+
+					if (constantValue.HasValue && constantValue.Value is string value)
+						excluded.Add(value);
+				}
+			}
+		}
+
+		return excluded;
+	}
+
+	/// <summary>
+	/// Escapes a string for use in a regular string literal.
+	/// </summary>
+	/// <param name="value">The string value to escape.</param>
+	/// <returns>The escaped string.</returns>
+	internal static string EscapeString(string value)
+		=> value.Replace("\\", "\\\\").Replace("\"", "\\\"");
+
+	/// <summary>
+	/// Escapes a string for use in a verbatim string literal.
+	/// </summary>
+	/// <param name="value">The string value to escape.</param>
+	/// <returns>The escaped string.</returns>
+	internal static string EscapeVerbatimString(string value)
+		=> value.Replace("\"", "\"\"");
+
+	/// <summary>
+	/// Transforms a <see cref="GeneratorAttributeSyntaxContext"/> into a tuple of class declaration syntax and semantic model.
+	/// </summary>
+	/// <param name="context">The generator attribute syntax context.</param>
+	/// <returns>A tuple of class declaration syntax and semantic model, or null if the target node is not a class declaration.</returns>
+	internal static (ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)? TransformClassSyntax(GeneratorAttributeSyntaxContext context)
+		=> context.TargetNode is not ClassDeclarationSyntax classSyntax ? null : ((ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)?)(classSyntax, context.SemanticModel);
+}

--- a/src/BB84.SourceGenerators/IniFileGenerator.cs
+++ b/src/BB84.SourceGenerators/IniFileGenerator.cs
@@ -7,6 +7,7 @@ using System.Text;
 
 using BB84.SourceGenerators.Attributes;
 using BB84.SourceGenerators.Extensions;
+using BB84.SourceGenerators.Helpers;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -37,15 +38,10 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 				.ForAttributeWithMetadataName(
 					fullyQualifiedMetadataName: GeneratorAttributeName,
 					predicate: static (node, _) => node is ClassDeclarationSyntax,
-					transform: static (ctx, _) => Transform(ctx))
+					transform: static (ctx, _) => GeneratorHelpers.TransformClassSyntax(ctx))
 				.Where(static result => result is not null);
 
 		context.RegisterSourceOutput(provider, Execute);
-	}
-
-	private static (ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)? Transform(GeneratorAttributeSyntaxContext context)
-	{
-		return context.TargetNode is not ClassDeclarationSyntax classSyntax ? null : ((ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)?)(classSyntax, context.SemanticModel);
 	}
 
 	private void Execute(SourceProductionContext context, (ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)? input)
@@ -58,7 +54,7 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 
 		string className = classDeclaration.Identifier.Text;
 		string namespaceName = classDeclaration.GetNamespace();
-		string accessibility = GetAccessibility(classDeclaration);
+		string accessibility = GeneratorHelpers.GetAccessibility(classDeclaration);
 		string stringComparison = GetStringComparison(classDeclaration, semanticModel);
 		string sectionDelimiter = GetSectionDelimiter(classDeclaration, semanticModel);
 		bool serializeComments = GetSerializeComments(classDeclaration);
@@ -182,14 +178,14 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 			sb.AppendLine("      {");
 
 			if (serializeComments && section.Comment is not null)
-				sb.AppendLine($"        sb.AppendLine(\"; {EscapeString(section.Comment)}\");");
+				sb.AppendLine($"        sb.AppendLine(\"; {GeneratorHelpers.EscapeString(section.Comment)}\");");
 
 			sb.AppendLine($"        sb.AppendLine(\"[{section.SectionName}]\");");
 
 			foreach (ValueInfo value in section.Values)
 			{
 				if (serializeComments && value.Comment is not null)
-					sb.AppendLine($"        sb.AppendLine(\"; {EscapeString(value.Comment)}\");");
+					sb.AppendLine($"        sb.AppendLine(\"; {GeneratorHelpers.EscapeString(value.Comment)}\");");
 
 				sb.AppendLine($"        sb.AppendLine(\"{value.KeyName}=\" + {GetToStringExpression($"instance.{section.PropertyPath}.{value.PropertyName}", value)});");
 			}
@@ -565,9 +561,6 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 		return null;
 	}
 
-	private static string EscapeString(string value)
-		=> value.Replace("\\", "\\\\").Replace("\"", "\\\"");
-
 	private static string BuildNullCheck(string propertyPath)
 	{
 		string[] segments = propertyPath.Split('.');
@@ -581,23 +574,6 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 		}
 
 		return string.Join(" && ", checks);
-	}
-
-	private static string GetAccessibility(ClassDeclarationSyntax classDeclaration)
-	{
-		foreach (SyntaxToken modifier in classDeclaration.Modifiers)
-		{
-			if (modifier.IsKind(SyntaxKind.PublicKeyword))
-				return "public";
-			if (modifier.IsKind(SyntaxKind.InternalKeyword))
-				return "internal";
-			if (modifier.IsKind(SyntaxKind.ProtectedKeyword))
-				return "protected";
-			if (modifier.IsKind(SyntaxKind.PrivateKeyword))
-				return "private";
-		}
-
-		return "internal";
 	}
 
 	private sealed record SectionInfo(

--- a/src/BB84.SourceGenerators/ToStringGenerator.cs
+++ b/src/BB84.SourceGenerators/ToStringGenerator.cs
@@ -8,6 +8,7 @@ using System.Text;
 
 using BB84.SourceGenerators.Attributes;
 using BB84.SourceGenerators.Extensions;
+using BB84.SourceGenerators.Helpers;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -33,14 +34,11 @@ public sealed class ToStringGenerator : IIncrementalGenerator
 				.ForAttributeWithMetadataName(
 					fullyQualifiedMetadataName: GeneratorAttributeName,
 					predicate: static (node, _) => node is ClassDeclarationSyntax,
-					transform: static (ctx, _) => Transform(ctx))
+					transform: static (ctx, _) => GeneratorHelpers.TransformClassSyntax(ctx))
 				.Where(static result => result is not null);
 
 		context.RegisterSourceOutput(provider, Execute);
 	}
-
-	private static (ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)? Transform(GeneratorAttributeSyntaxContext context)
-		=> context.TargetNode is not ClassDeclarationSyntax classSyntax ? null : ((ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)?)(classSyntax, context.SemanticModel);
 
 	private void Execute(SourceProductionContext context, (ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)? input)
 	{
@@ -56,12 +54,12 @@ public sealed class ToStringGenerator : IIncrementalGenerator
 
 		string className = classSymbol.Name;
 		string namespaceName = classDeclaration.GetNamespace();
-		string accessibility = GetAccessibility(classDeclaration);
+		string accessibility = GeneratorHelpers.GetAccessibility(classDeclaration);
 
-		HashSet<string> excludedProperties = GetExcludedProperties(classDeclaration, semanticModel);
+		HashSet<string> excludedProperties = GeneratorHelpers.GetExcludedProperties(classDeclaration, semanticModel, "GenerateToString", "GenerateToStringAttribute");
 		ImmutableArray<string> properties = GetPublicProperties(classSymbol, excludedProperties);
 
-		List<(string Accessibility, string Name)> outerClasses = GetOuterClasses(classDeclaration);
+		List<(string Accessibility, string Name)> outerClasses = GeneratorHelpers.GetOuterClasses(classDeclaration);
 
 		StringBuilder sb = new();
 
@@ -156,62 +154,5 @@ public sealed class ToStringGenerator : IIncrementalGenerator
 		}
 
 		return builder.ToImmutable();
-	}
-
-	private static HashSet<string> GetExcludedProperties(ClassDeclarationSyntax classDeclaration, SemanticModel semanticModel)
-	{
-		HashSet<string> excluded = new(StringComparer.Ordinal);
-
-		foreach (AttributeListSyntax attributeList in classDeclaration.AttributeLists)
-		{
-			foreach (AttributeSyntax attribute in attributeList.Attributes)
-			{
-				string name = attribute.Name.ToString();
-
-				if (name is not "GenerateToString" and not "GenerateToStringAttribute")
-					continue;
-
-				if (attribute.ArgumentList is null)
-					continue;
-
-				foreach (AttributeArgumentSyntax argument in attribute.ArgumentList.Arguments)
-				{
-					Optional<object?> constantValue = semanticModel.GetConstantValue(argument.Expression);
-
-					if (constantValue.HasValue && constantValue.Value is string value)
-						excluded.Add(value);
-				}
-			}
-		}
-
-		return excluded;
-	}
-
-	private static string GetAccessibility(ClassDeclarationSyntax classDeclaration)
-	{
-		foreach (SyntaxToken modifier in classDeclaration.Modifiers)
-		{
-			if (modifier.IsKind(SyntaxKind.PublicKeyword))
-				return "public";
-			if (modifier.IsKind(SyntaxKind.InternalKeyword))
-				return "internal";
-		}
-
-		return "internal";
-	}
-
-	private static List<(string Accessibility, string Name)> GetOuterClasses(ClassDeclarationSyntax classDeclaration)
-	{
-		List<(string Accessibility, string Name)> outerClasses = [];
-		SyntaxNode? parent = classDeclaration.Parent;
-
-		while (parent is ClassDeclarationSyntax outerClass)
-		{
-			outerClasses.Add((GetAccessibility(outerClass), outerClass.Identifier.Text));
-			parent = outerClass.Parent;
-		}
-
-		outerClasses.Reverse();
-		return outerClasses;
 	}
 }

--- a/src/BB84.SourceGenerators/ValidatorGenerator.cs
+++ b/src/BB84.SourceGenerators/ValidatorGenerator.cs
@@ -9,6 +9,7 @@ using System.Text;
 using BB84.SourceGenerators.Analyzers;
 using BB84.SourceGenerators.Attributes;
 using BB84.SourceGenerators.Extensions;
+using BB84.SourceGenerators.Helpers;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -27,13 +28,6 @@ public sealed class ValidatorGenerator : IIncrementalGenerator
 	private static readonly string GeneratorName = typeof(ValidatorGenerator).FullName;
 	private static readonly string GeneratorAttributeName = typeof(GenerateValidatorAttribute).FullName;
 
-	private const string RequiredAttributeName = "System.ComponentModel.DataAnnotations.RequiredAttribute";
-	private const string RangeAttributeName = "System.ComponentModel.DataAnnotations.RangeAttribute";
-	private const string StringLengthAttributeName = "System.ComponentModel.DataAnnotations.StringLengthAttribute";
-	private const string MinLengthAttributeName = "System.ComponentModel.DataAnnotations.MinLengthAttribute";
-	private const string MaxLengthAttributeName = "System.ComponentModel.DataAnnotations.MaxLengthAttribute";
-	private const string RegularExpressionAttributeName = "System.ComponentModel.DataAnnotations.RegularExpressionAttribute";
-
 	/// <inheritdoc/>
 	public void Initialize(IncrementalGeneratorInitializationContext context)
 	{
@@ -42,15 +36,10 @@ public sealed class ValidatorGenerator : IIncrementalGenerator
 				.ForAttributeWithMetadataName(
 					fullyQualifiedMetadataName: GeneratorAttributeName,
 					predicate: static (node, _) => node is ClassDeclarationSyntax,
-					transform: static (ctx, _) => Transform(ctx))
+					transform: static (ctx, _) => GeneratorHelpers.TransformClassSyntax(ctx))
 				.Where(static result => result is not null);
 
 		context.RegisterSourceOutput(provider, Execute);
-	}
-
-	private static (ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)? Transform(GeneratorAttributeSyntaxContext context)
-	{
-		return context.TargetNode is not ClassDeclarationSyntax classSyntax ? null : ((ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)?)(classSyntax, context.SemanticModel);
 	}
 
 	private void Execute(SourceProductionContext context, (ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)? input)
@@ -74,11 +63,11 @@ public sealed class ValidatorGenerator : IIncrementalGenerator
 
 		string className = classSymbol.Name;
 		string namespaceName = classDeclaration.GetNamespace();
-		string accessibility = GetAccessibility(classDeclaration);
+		string accessibility = GeneratorHelpers.GetAccessibility(classDeclaration);
 
 		ImmutableArray<PropertyValidationInfo> validatedProperties = GetValidatedProperties(classSymbol);
 
-		List<(string Accessibility, string Name)> outerClasses = GetOuterClasses(classDeclaration);
+		List<(string Accessibility, string Name)> outerClasses = GeneratorHelpers.GetOuterClasses(classDeclaration);
 
 		StringBuilder sb = new();
 
@@ -261,9 +250,9 @@ public sealed class ValidatorGenerator : IIncrementalGenerator
 
 	private static void AppendRegularExpressionValidation(StringBuilder sb, string propertyName, ValidationRule rule, string bodyIndent)
 	{
-		string message = rule.ErrorMessage ?? $"The field {propertyName} must match the regular expression '{EscapeString(rule.Pattern!)}'.";
+		string message = rule.ErrorMessage ?? $"The field {propertyName} must match the regular expression '{GeneratorHelpers.EscapeString(rule.Pattern!)}'.";
 
-		sb.AppendLine($"{bodyIndent}if ({propertyName} != null && !Regex.IsMatch({propertyName}, @\"{EscapeVerbatimString(rule.Pattern!)}\"))");
+		sb.AppendLine($"{bodyIndent}if ({propertyName} != null && !Regex.IsMatch({propertyName}, @\"{GeneratorHelpers.EscapeVerbatimString(rule.Pattern!)}\"))");
 		AppendAddError(sb, propertyName, message, bodyIndent);
 	}
 
@@ -272,7 +261,7 @@ public sealed class ValidatorGenerator : IIncrementalGenerator
 		sb.AppendLine($"{bodyIndent}{{");
 		sb.AppendLine($"{bodyIndent}  if (!errors.ContainsKey(\"{propertyName}\"))");
 		sb.AppendLine($"{bodyIndent}    errors[\"{propertyName}\"] = new List<string>();");
-		sb.AppendLine($"{bodyIndent}  errors[\"{propertyName}\"].Add(\"{EscapeString(message)}\");");
+		sb.AppendLine($"{bodyIndent}  errors[\"{propertyName}\"].Add(\"{GeneratorHelpers.EscapeString(message)}\");");
 		sb.AppendLine($"{bodyIndent}}}");
 	}
 
@@ -318,12 +307,12 @@ public sealed class ValidatorGenerator : IIncrementalGenerator
 
 				ValidationRule? rule = attributeName switch
 				{
-					RequiredAttributeName => ParseRequiredAttribute(attribute),
-					RangeAttributeName => ParseRangeAttribute(attribute),
-					StringLengthAttributeName => ParseStringLengthAttribute(attribute),
-					MinLengthAttributeName => ParseMinLengthAttribute(attribute),
-					MaxLengthAttributeName => ParseMaxLengthAttribute(attribute),
-					RegularExpressionAttributeName => ParseRegularExpressionAttribute(attribute),
+					DataAnnotationNames.Required => ParseRequiredAttribute(attribute),
+					DataAnnotationNames.Range => ParseRangeAttribute(attribute),
+					DataAnnotationNames.StringLength => ParseStringLengthAttribute(attribute),
+					DataAnnotationNames.MinLength => ParseMinLengthAttribute(attribute),
+					DataAnnotationNames.MaxLength => ParseMaxLengthAttribute(attribute),
+					DataAnnotationNames.RegularExpression => ParseRegularExpressionAttribute(attribute),
 					_ => null
 				};
 
@@ -448,34 +437,6 @@ public sealed class ValidatorGenerator : IIncrementalGenerator
 		return default;
 	}
 
-	private static string GetAccessibility(ClassDeclarationSyntax classDeclaration)
-	{
-		foreach (SyntaxToken modifier in classDeclaration.Modifiers)
-		{
-			if (modifier.IsKind(SyntaxKind.PublicKeyword))
-				return "public";
-			if (modifier.IsKind(SyntaxKind.InternalKeyword))
-				return "internal";
-		}
-
-		return "internal";
-	}
-
-	private static List<(string Accessibility, string Name)> GetOuterClasses(ClassDeclarationSyntax classDeclaration)
-	{
-		List<(string Accessibility, string Name)> outerClasses = [];
-		SyntaxNode? parent = classDeclaration.Parent;
-
-		while (parent is ClassDeclarationSyntax outerClass)
-		{
-			outerClasses.Add((GetAccessibility(outerClass), outerClass.Identifier.Text));
-			parent = outerClass.Parent;
-		}
-
-		outerClasses.Reverse();
-		return outerClasses;
-	}
-
 	private static bool IsCollectionType(ITypeSymbol type)
 	{
 		if (type.TypeKind == TypeKind.Array)
@@ -492,12 +453,6 @@ public sealed class ValidatorGenerator : IIncrementalGenerator
 
 		return type is INamedTypeSymbol namedType && namedType.OriginalDefinition.SpecialType == SpecialType.System_Collections_Generic_IEnumerable_T;
 	}
-
-	private static string EscapeString(string value)
-		=> value.Replace("\\", "\\\\").Replace("\"", "\\\"");
-
-	private static string EscapeVerbatimString(string value)
-		=> value.Replace("\"", "\"\"");
 
 	private enum ValidationKind
 	{


### PR DESCRIPTION
**Changes:**

- Introduce `GeneratorHelpers` for shared logic (accessibility, outer class, property exclusion, string escaping) and refactor all source generators to use it.
- Add `DataAnnotationNames` for validator attribute names.
- Remove duplicated code from generators, improving maintainability and consistency.
- Minor cleanups and simplifications included.

closes #67 