### PR TITLE
feat: Add instance `Load` method to INI file generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ mockFileProvider.Setup(x => x.ReadAllText(It.IsAny<string>())).Returns("test con
 
 ### 4. INI File Generator
 
-Generates static `Read` and `Write` methods for classes, enabling compile-time INI file serialization and deserialization based on decorated properties.
+Generates static `Read` and `Write` methods and an instance `Load` method for classes, enabling compile-time INI file serialization, deserialization, and instance-to-instance value copying based on decorated properties.
 
 #### Attributes
 
@@ -319,10 +319,11 @@ public class DatabaseSection
 
 #### Generated Methods
 
-The generator creates the following static methods on the decorated class:
+The generator creates the following methods on the decorated class:
 
-- `Read(string content)` - Parses an INI file string and returns a deserialized instance
-- `Write(TClass instance)` - Serializes an instance into an INI file string
+- `Read(string content)` - Static method that parses an INI file string and returns a deserialized instance
+- `Write(TClass instance)` - Static method that serializes an instance into an INI file string
+- `Load(TClass other)` - Instance method that copies all section/value properties from another instance into this instance (null-safe per section)
 
 #### Usage Example
 
@@ -340,6 +341,11 @@ config.Database.Timeout = 60.0;
 
 string output = AppConfig.Write(config);
 File.WriteAllText("config.ini", output);
+
+// Loading values from another instance
+string fileContent = File.ReadAllText("updated.ini");
+AppConfig newConfig = AppConfig.Read(fileContent);
+config.Load(newConfig); // copies all section values from newConfig into config
 ```
 
 **Output:**

--- a/src/BB84.SourceGenerators/IniFileGenerator.cs
+++ b/src/BB84.SourceGenerators/IniFileGenerator.cs
@@ -75,6 +75,7 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 
 		AppendReadMethod(sb, className, accessibility, sections, stringComparison);
 		AppendWriteMethod(sb, className, sections, serializeComments);
+		AppendLoadMethod(sb, className, sections);
 
 		sb.AppendLine("  }");
 		sb.AppendLine("}");
@@ -195,6 +196,30 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 
 		sb.AppendLine();
 		sb.AppendLine("      return sb.ToString();");
+		sb.AppendLine("    }");
+	}
+
+	private static void AppendLoadMethod(StringBuilder sb, string className, List<SectionInfo> sections)
+	{
+		sb.AppendLine();
+		sb.AppendLine("    /// <summary>");
+		sb.AppendLine($"    /// Loads values from the specified <paramref name=\"other\"/> instance into this instance.");
+		sb.AppendLine("    /// </summary>");
+		sb.AppendLine($"    /// <param name=\"other\">The source <see cref=\"{className}\"/> instance to copy values from.</param>");
+		sb.AppendLine($"    public void Load({className} other)");
+		sb.AppendLine("    {");
+
+		foreach (SectionInfo section in sections)
+		{
+			sb.AppendLine($"      if ({section.PropertyPath} != null && other.{section.PropertyPath} != null)");
+			sb.AppendLine("      {");
+
+			foreach (ValueInfo value in section.Values)
+				sb.AppendLine($"        {section.PropertyPath}.{value.PropertyName} = other.{section.PropertyPath}.{value.PropertyName};");
+
+			sb.AppendLine("      }");
+		}
+
 		sb.AppendLine("    }");
 	}
 

--- a/tests/BB84.SourceGenerators.Tests/IniFileGeneratorTests.cs
+++ b/tests/BB84.SourceGenerators.Tests/IniFileGeneratorTests.cs
@@ -666,6 +666,56 @@ public sealed class IniFileGeneratorTests
 		Assert.AreEqual("TestApp", deserialized.General.AppName);
 		Assert.AreEqual(5, deserialized.General.Version);
 	}
+
+	[TestMethod]
+	public void LoadShouldCopyValuesFromOtherInstance()
+	{
+		TestIniFile target = new()
+		{
+			General = new TestGeneralSection { AppName = "Old", Version = 1, Enabled = false },
+			Database = new TestDatabaseSection { Host = "old-host", Port = 1234, Timeout = 10.0 }
+		};
+
+		TestIniFile source = new()
+		{
+			General = new TestGeneralSection { AppName = "New", Version = 2, Enabled = true },
+			Database = new TestDatabaseSection { Host = "new-host", Port = 5678, Timeout = 30.0 }
+		};
+
+		target.Load(source);
+
+		Assert.AreEqual("New", target.General.AppName);
+		Assert.AreEqual(2, target.General.Version);
+		Assert.IsTrue(target.General.Enabled);
+		Assert.AreEqual("new-host", target.Database.Host);
+		Assert.AreEqual(5678, target.Database.Port);
+		Assert.AreEqual(30.0, target.Database.Timeout);
+	}
+
+	[TestMethod]
+	public void LoadShouldSkipNullSections()
+	{
+		TestIniFile target = new()
+		{
+			General = new TestGeneralSection { AppName = "Keep", Version = 1, Enabled = true },
+			Database = null
+		};
+
+		TestIniFile source = new()
+		{
+			General = new TestGeneralSection { AppName = "New", Version = 5, Enabled = false },
+			Database = new TestDatabaseSection { Host = "host", Port = 9999, Timeout = 99.0 }
+		};
+
+		target.Load(source);
+
+		// General should be updated
+		Assert.AreEqual("New", target.General.AppName);
+		Assert.AreEqual(5, target.General.Version);
+
+		// Database should remain null (target section is null)
+		Assert.IsNull(target.Database);
+	}
 }
 
 #region Test Types


### PR DESCRIPTION
**Changes:**

- The INI file generator now emits an instance `Load(TClass other)` method that copies all section/value properties from another instance, with null section safety.
- Updated the `README` to document this method and added usage examples.
- Added unit tests to verify correct value copying and null section handling.

closes #76 