### PR TITLE
fix: Improve nullable section handling in INI file generator

### DIFF
--- a/src/BB84.SourceGenerators/IniFileGenerator.cs
+++ b/src/BB84.SourceGenerators/IniFileGenerator.cs
@@ -211,7 +211,9 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 
 		foreach (SectionInfo section in sections)
 		{
-			sb.AppendLine($"      if ({section.PropertyPath} != null && other.{section.PropertyPath} != null)");
+      string targetNullCheck = BuildNullCheck($"this.{section.PropertyPath}");
+			string sourceNullCheck = BuildNullCheck($"other.{section.PropertyPath}");
+			sb.AppendLine($"      if ({targetNullCheck} && {sourceNullCheck})");
 			sb.AppendLine("      {");
 
 			foreach (ValueInfo value in section.Values)
@@ -266,11 +268,19 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 
 			List<ValueInfo> values = GetValues(sectionType, serializeComments);
 
+			string sectionTypeName = sectionType
+				.WithNullableAnnotation(NullableAnnotation.NotAnnotated)
+				.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)
+				.Replace("global::", string.Empty);
+
+			if (sectionTypeName.EndsWith("?", StringComparison.Ordinal))
+				sectionTypeName = sectionTypeName[..^1];
+
 			sections.Add(new SectionInfo(
 				PropertyName: propertySymbol.Name,
 				PropertyPath: propertyPath,
 				SectionName: sectionName,
-				TypeName: sectionType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+        TypeName: sectionTypeName,
 				NeedsInitialization: needsInit,
 				Values: values,
 				Comment: comment
@@ -322,11 +332,19 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 
 			List<ValueInfo> values = GetValues(sectionType, serializeComments);
 
+     string sectionTypeName = sectionType
+				.WithNullableAnnotation(NullableAnnotation.NotAnnotated)
+				.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)
+				.Replace("global::", string.Empty);
+
+			if (sectionTypeName.EndsWith("?", StringComparison.Ordinal))
+				sectionTypeName = sectionTypeName[..^1];
+
 			sections.Add(new SectionInfo(
 				PropertyName: propertySymbol.Name,
 				PropertyPath: propertyPath,
 				SectionName: fullSectionName,
-				TypeName: sectionType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+        TypeName: sectionTypeName,
 				NeedsInitialization: false,
 				Values: values,
 				Comment: comment

--- a/tests/BB84.SourceGenerators.Tests/IniFileGeneratorTests.cs
+++ b/tests/BB84.SourceGenerators.Tests/IniFileGeneratorTests.cs
@@ -716,6 +716,38 @@ public sealed class IniFileGeneratorTests
 		// Database should remain null (target section is null)
 		Assert.IsNull(target.Database);
 	}
+
+	[TestMethod]
+	public void LoadShouldCopyNestedSectionValues()
+	{
+		TestIniFileWithNestedSection target = new() { Section = new() };
+		target.Section.Domain = "old-domain";
+		target.Section.SubSection.Foo = "old-foo";
+
+		TestIniFileWithNestedSection source = new() { Section = new() };
+		source.Section.Domain = "new-domain";
+		source.Section.SubSection.Foo = "new-foo";
+
+		target.Load(source);
+
+		Assert.AreEqual("new-domain", target.Section.Domain);
+		Assert.AreEqual("new-foo", target.Section.SubSection.Foo);
+	}
+
+	[TestMethod]
+	public void LoadShouldNotThrowWhenNestedParentIsNull()
+	{
+		TestIniFileWithNestedSection target = new();
+		TestIniFileWithNestedSection source = new() { Section = new() };
+
+		target.Section = null!;
+		source.Section.Domain = "new-domain";
+		source.Section.SubSection.Foo = "new-foo";
+
+		target.Load(source);
+
+		Assert.IsNull(target.Section);
+	}
 }
 
 #region Test Types
@@ -834,7 +866,7 @@ internal sealed partial class TestIniFileCaseSensitive
 internal sealed partial class TestIniFileWithNestedSection
 {
 	[GenerateIniFileSection]
-	public TestSection Section { get; set; } = new TestSection();
+	public TestSection? Section { get; set; }
 }
 
 public class TestSection


### PR DESCRIPTION
**Enhanced codegen to properly handle nullable section types:**

- Load method now uses robust null checks for nested/nullable sections
- Section type names are stripped of nullable annotations in output
- Added tests for nested section value copying and null safety
- Made test Section property nullable to match new logic

closes #78 