### PR TITLE
fix: Improve `DescriptionAttribute` detection in enum generator

### DIFF
--- a/src/BB84.SourceGenerators/EnumeratorExtensionsGenerator.cs
+++ b/src/BB84.SourceGenerators/EnumeratorExtensionsGenerator.cs
@@ -27,21 +27,19 @@ public sealed class EnumeratorExtensionsGenerator : IIncrementalGenerator
 	/// <inheritdoc/>
 	public void Initialize(IncrementalGeneratorInitializationContext context)
 	{
-		IncrementalValuesProvider<SyntaxNode> provider = context.SyntaxProvider
-			.ForAttributeWithMetadataName(
-				fullyQualifiedMetadataName: GeneratorAttributeName,
-				predicate: (node, _) => Predicate(node),
-				transform: (context, _) => Transform(context.TargetNode))
-			.Where(node => node is not null);
+		IncrementalValuesProvider<(EnumDeclarationSyntax EnumDeclaration, SemanticModel SemanticModel)> provider = context.SyntaxProvider
+			 .ForAttributeWithMetadataName(
+				 fullyQualifiedMetadataName: GeneratorAttributeName,
+				 predicate: (node, _) => Predicate(node),
+				transform: (context, _) => Transform(context));
 
 		context.RegisterSourceOutput(provider, Execute);
 	}
 
 	/// <inheritdoc/>
-	private void Execute(SourceProductionContext context, SyntaxNode syntaxNode)
+	private void Execute(SourceProductionContext context, (EnumDeclarationSyntax EnumDeclaration, SemanticModel SemanticModel) data)
 	{
-		if (syntaxNode is not EnumDeclarationSyntax enumDeclaration)
-			return;
+		EnumDeclarationSyntax enumDeclaration = data.EnumDeclaration;
 
 		ImmutableArray<EnumMemberDeclarationSyntax> members = [.. enumDeclaration.Members
 				.OfType<EnumMemberDeclarationSyntax>()
@@ -62,7 +60,7 @@ public sealed class EnumeratorExtensionsGenerator : IIncrementalGenerator
 
 		AppendToStringFast(sourceBuilder, enumName, members);
 		AppendIsDefinedFast(sourceBuilder, enumName, members);
-		AppendGetDescriptionFast(sourceBuilder, enumName, members);
+		AppendGetDescriptionFast(sourceBuilder, enumName, members, data.SemanticModel);
 		AppendGetNamesFast(sourceBuilder, enumName, members);
 		AppendGetValuesFast(sourceBuilder, enumName, members);
 
@@ -73,8 +71,8 @@ public sealed class EnumeratorExtensionsGenerator : IIncrementalGenerator
 	}
 
 	/// <inheritdoc/>
-	private static SyntaxNode Transform(SyntaxNode targetNode)
-		=> (EnumDeclarationSyntax)targetNode;
+	private static (EnumDeclarationSyntax EnumDeclaration, SemanticModel SemanticModel) Transform(GeneratorAttributeSyntaxContext context)
+		=> ((EnumDeclarationSyntax)context.TargetNode, context.SemanticModel);
 
 	/// <inheritdoc/>
 	private static bool Predicate(SyntaxNode node)
@@ -218,7 +216,7 @@ public sealed class EnumeratorExtensionsGenerator : IIncrementalGenerator
 		builder.AppendLine();
 	}
 
-	private static void AppendGetDescriptionFast(StringBuilder builder, string enumName, ImmutableArray<EnumMemberDeclarationSyntax> members)
+	private static void AppendGetDescriptionFast(StringBuilder builder, string enumName, ImmutableArray<EnumMemberDeclarationSyntax> members, SemanticModel semanticModel)
 	{
 		builder.AppendLine("    /// <summary>");
 		builder.AppendLine($"    /// Returns the description of the <see cref=\"{enumName}\"/> enumeration if the");
@@ -234,7 +232,7 @@ public sealed class EnumeratorExtensionsGenerator : IIncrementalGenerator
 		foreach (EnumMemberDeclarationSyntax member in members)
 		{
 			string memberName = member.Identifier.Text;
-			string? description = GetDescriptionFromAttributes(member);
+			string? description = GetDescriptionFromAttributes(member, semanticModel);
 
 			if (description is not null)
 				builder.AppendLine($"        {enumName}.{memberName} => \"{description}\",");
@@ -247,19 +245,33 @@ public sealed class EnumeratorExtensionsGenerator : IIncrementalGenerator
 		builder.AppendLine();
 	}
 
-	private static string? GetDescriptionFromAttributes(EnumMemberDeclarationSyntax member)
+	private static string? GetDescriptionFromAttributes(EnumMemberDeclarationSyntax member, SemanticModel semanticModel)
 	{
+		INamedTypeSymbol? descriptionAttributeSymbol = semanticModel.Compilation.GetTypeByMetadataName("System.ComponentModel.DescriptionAttribute");
+
+		if (descriptionAttributeSymbol is null)
+			return null;
+
 		foreach (AttributeListSyntax attributeList in member.AttributeLists)
 		{
 			foreach (AttributeSyntax attribute in attributeList.Attributes)
 			{
-				if (attribute.Name.ToString() == "System.ComponentModel.Description")
+				SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(attribute);
+				if (symbolInfo.Symbol is not IMethodSymbol attributeConstructor)
+					continue;
+
+				if (!SymbolEqualityComparer.Default.Equals(attributeConstructor.ContainingType, descriptionAttributeSymbol))
+					continue;
+
+				if (attribute.ArgumentList?.Arguments.Count > 0)
 				{
-					if (attribute.ArgumentList?.Arguments.Count > 0)
-					{
-						AttributeArgumentSyntax argument = attribute.ArgumentList.Arguments[0];
-						return argument.ToString().Trim('"'); // Remove quotes around the string
-					}
+					AttributeArgumentSyntax argument = attribute.ArgumentList.Arguments[0];
+					Optional<object?> descriptionValue = semanticModel.GetConstantValue(argument.Expression);
+
+					if (descriptionValue.HasValue && descriptionValue.Value is string description)
+						return description;
+
+					return argument.ToString().Trim('"');
 				}
 			}
 		}

--- a/tests/BB84.SourceGenerators.Tests/EnumeratorExtensionsGeneratorTests.cs
+++ b/tests/BB84.SourceGenerators.Tests/EnumeratorExtensionsGeneratorTests.cs
@@ -5,6 +5,8 @@
 // LICENSE file in the root directory of this source tree.
 using BB84.SourceGenerators.Attributes;
 
+using DescriptionAttribute = System.ComponentModel.DescriptionAttribute;
+
 namespace BB84.SourceGenerators.Tests;
 
 [TestClass]
@@ -78,8 +80,8 @@ public sealed class EnumeratorExtensionsGeneratorTests
 	public void GetDescriptionFastShouldReturnCorrectDescriptions()
 	{
 		Assert.AreEqual("No value", GeneratorTestType.None.GetDescriptionFast());
-		Assert.AreEqual(nameof(GeneratorTestType.One), GeneratorTestType.One.GetDescriptionFast());
-		Assert.AreEqual(nameof(GeneratorTestType.Two), GeneratorTestType.Two.GetDescriptionFast());
+		Assert.AreEqual("One value", GeneratorTestType.One.GetDescriptionFast());
+		Assert.AreEqual("Two value", GeneratorTestType.Two.GetDescriptionFast());
 		Assert.AreEqual(nameof(GeneratorTestType.Three), GeneratorTestType.Three.GetDescriptionFast());
 	}
 }
@@ -89,7 +91,9 @@ public enum GeneratorTestType
 {
 	[System.ComponentModel.Description("No value")]
 	None = 0,
+	[DescriptionAttribute("One value")]
 	One = 1,
+	[Description("Two value")]
 	Two = 2,
 	Three = 3
 }

--- a/tests/BB84.SourceGenerators.Tests/GeneratorDriverTests.cs
+++ b/tests/BB84.SourceGenerators.Tests/GeneratorDriverTests.cs
@@ -26,6 +26,40 @@ public sealed class GeneratorDriverTests
 	];
 
 	[TestMethod]
+	public void EnumeratorExtensionsGeneratorShouldDetectDescriptionAttributeWhenUnqualified()
+	{
+		string source = @"
+using System.ComponentModel;
+using BB84.SourceGenerators.Attributes;
+
+namespace TestNamespace
+{
+	[GenerateEnumeratorExtensions]
+	public enum MyEnum
+	{
+		[Description(""No value"")]
+		None = 0,
+		[DescriptionAttribute(""One value"")]
+		One = 1,
+		[System.ComponentModel.Description(""Two value"")]
+		Two = 2,
+		Three = 3
+	}
+}";
+
+		(ImmutableArray<Diagnostic> diagnostics, string[] generatedSources) = RunGenerator<EnumeratorExtensionsGenerator>(source);
+
+		Assert.IsEmpty(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
+		Assert.IsNotEmpty(generatedSources);
+
+		string generated = generatedSources.First(s => s.Contains("GetDescriptionFast(this MyEnum value)"));
+		Assert.Contains("MyEnum.None => \"No value\"", generated);
+		Assert.Contains("MyEnum.One => \"One value\"", generated);
+		Assert.Contains("MyEnum.Two => \"Two value\"", generated);
+		Assert.Contains("MyEnum.Three => nameof(MyEnum.Three)", generated);
+	}
+
+	[TestMethod]
 	public void ToStringGeneratorShouldGenerateSource()
 	{
 		string source = @"


### PR DESCRIPTION
**Changes:**

- Refactored the generator to use semantic analysis for extracting `DescriptionAttribute` values from enum members, supporting both qualified and unqualified usages.
- Updated the pipeline to pass `SemanticModel`, and enhanced tests to verify correct handling of all `DescriptionAttribute` forms.

closes #80 