### PR TITLE
feat: refactored duplicated property info records

### DIFF
--- a/src/BB84.SourceGenerators/BuilderGenerator.cs
+++ b/src/BB84.SourceGenerators/BuilderGenerator.cs
@@ -9,6 +9,7 @@ using System.Text;
 using BB84.SourceGenerators.Attributes;
 using BB84.SourceGenerators.Extensions;
 using BB84.SourceGenerators.Helpers;
+using BB84.SourceGenerators.Models;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -57,7 +58,7 @@ public sealed class BuilderGenerator : IIncrementalGenerator
 		string accessibility = GeneratorHelpers.GetAccessibility(classDeclaration);
 		string builderClassName = $"{className}Builder";
 
-		ImmutableArray<PropertyInfo> properties = GetSettableProperties(classSymbol);
+		ImmutableArray<PropertyDescriptor> properties = GeneratorHelpers.GetPropertyDescriptors(classSymbol, requireSetter: true);
 
 		if (properties.Length == 0)
 			return;
@@ -99,7 +100,7 @@ public sealed class BuilderGenerator : IIncrementalGenerator
 		context.AddSource(hintName, sb.ToString());
 	}
 
-	private static void AppendBuilderClass(StringBuilder sb, string className, string builderClassName, string accessibility, ImmutableArray<PropertyInfo> properties, int indentLevel = 1)
+	private static void AppendBuilderClass(StringBuilder sb, string className, string builderClassName, string accessibility, ImmutableArray<PropertyDescriptor> properties, int indentLevel = 1)
 	{
 		string indent = new(' ', indentLevel * 2);
 		string innerIndent = new(' ', (indentLevel + 1) * 2);
@@ -112,7 +113,7 @@ public sealed class BuilderGenerator : IIncrementalGenerator
 		sb.AppendLine($"{indent}{{");
 
 		// Fields
-		foreach (PropertyInfo prop in properties)
+		foreach (PropertyDescriptor prop in properties)
 		{
 			string fieldName = $"_{char.ToLowerInvariant(prop.Name[0])}{prop.Name.Substring(1)}";
 			string typeName = prop.IsReferenceType && prop.IsNullable ? $"{prop.TypeName}?" : prop.TypeName;
@@ -123,7 +124,7 @@ public sealed class BuilderGenerator : IIncrementalGenerator
 		sb.AppendLine();
 
 		// With methods
-		foreach (PropertyInfo prop in properties)
+		foreach (PropertyDescriptor prop in properties)
 		{
 			string fieldName = $"_{char.ToLowerInvariant(prop.Name[0])}{prop.Name.Substring(1)}";
 			string typeName = prop.IsReferenceType && prop.IsNullable ? $"{prop.TypeName}?" : prop.TypeName;
@@ -153,7 +154,7 @@ public sealed class BuilderGenerator : IIncrementalGenerator
 		string deepIndent = new(' ', (indentLevel + 3) * 2);
 		for (int i = 0; i < properties.Length; i++)
 		{
-			PropertyInfo prop = properties[i];
+			PropertyDescriptor prop = properties[i];
 			string fieldName = $"_{char.ToLowerInvariant(prop.Name[0])}{prop.Name.Substring(1)}";
 			string separator = i < properties.Length - 1 ? "," : string.Empty;
 			sb.AppendLine($"{deepIndent}{prop.Name} = {fieldName}{separator}");
@@ -163,40 +164,5 @@ public sealed class BuilderGenerator : IIncrementalGenerator
 		sb.AppendLine($"{innerIndent}}}");
 
 		sb.AppendLine($"{indent}}}");
-	}
-
-	private static ImmutableArray<PropertyInfo> GetSettableProperties(INamedTypeSymbol classSymbol)
-	{
-		ImmutableArray<PropertyInfo>.Builder builder = ImmutableArray.CreateBuilder<PropertyInfo>();
-
-		foreach (ISymbol member in classSymbol.GetMembers())
-		{
-			if (member is not IPropertySymbol propertySymbol)
-				continue;
-
-			if (propertySymbol.DeclaredAccessibility != Accessibility.Public)
-				continue;
-
-			if (propertySymbol.IsReadOnly || propertySymbol.IsStatic || propertySymbol.SetMethod is null)
-				continue;
-
-			if (propertySymbol.SetMethod.DeclaredAccessibility != Accessibility.Public)
-				continue;
-
-			bool isReferenceType = propertySymbol.Type.IsReferenceType;
-			bool isNullable = propertySymbol.NullableAnnotation == NullableAnnotation.Annotated;
-
-			builder.Add(new PropertyInfo(propertySymbol.Name, propertySymbol.Type.ToFullyQualifiedDisplayString(), isReferenceType, isNullable));
-		}
-
-		return builder.ToImmutable();
-	}
-
-	private readonly struct PropertyInfo(string name, string typeName, bool isReferenceType, bool isNullable)
-	{
-		public string Name { get; } = name;
-		public string TypeName { get; } = typeName;
-		public bool IsReferenceType { get; } = isReferenceType;
-		public bool IsNullable { get; } = isNullable;
 	}
 }

--- a/src/BB84.SourceGenerators/CloneableGenerator.cs
+++ b/src/BB84.SourceGenerators/CloneableGenerator.cs
@@ -9,6 +9,7 @@ using System.Text;
 using BB84.SourceGenerators.Attributes;
 using BB84.SourceGenerators.Extensions;
 using BB84.SourceGenerators.Helpers;
+using BB84.SourceGenerators.Models;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -60,7 +61,7 @@ public sealed class CloneableGenerator : IIncrementalGenerator
 		string accessibility = GeneratorHelpers.GetAccessibility(classDeclaration);
 
 		HashSet<string> excludedProperties = GeneratorHelpers.GetExcludedProperties(classDeclaration, semanticModel, "GenerateCloneable", "GenerateCloneableAttribute");
-		ImmutableArray<PropertyInfo> properties = GetPublicProperties(classSymbol, excludedProperties);
+		ImmutableArray<PropertyDescriptor> properties = GeneratorHelpers.GetPropertyDescriptors(classSymbol, excludedProperties, requireSetter: true, cloneableAttributeName: GeneratorAttributeName);
 
 		List<(string Accessibility, string Name)> outerClasses = GeneratorHelpers.GetOuterClasses(classDeclaration);
 
@@ -100,7 +101,7 @@ public sealed class CloneableGenerator : IIncrementalGenerator
 		context.AddSource(hintName, sb.ToString());
 	}
 
-	private static void AppendPartialClass(StringBuilder sb, string className, string accessibility, ImmutableArray<PropertyInfo> properties, int indentLevel = 1)
+	private static void AppendPartialClass(StringBuilder sb, string className, string accessibility, ImmutableArray<PropertyDescriptor> properties, int indentLevel = 1)
 	{
 		string indent = new(' ', indentLevel * 2);
 
@@ -116,7 +117,7 @@ public sealed class CloneableGenerator : IIncrementalGenerator
 		sb.AppendLine($"{indent}}}");
 	}
 
-	private static void AppendCloneMethod(StringBuilder sb, string className, ImmutableArray<PropertyInfo> properties, int indentLevel)
+	private static void AppendCloneMethod(StringBuilder sb, string className, ImmutableArray<PropertyDescriptor> properties, int indentLevel)
 	{
 		string indent = new(' ', indentLevel * 2);
 		string bodyIndent = new(' ', (indentLevel + 1) * 2);
@@ -129,14 +130,14 @@ public sealed class CloneableGenerator : IIncrementalGenerator
 		sb.AppendLine($"{indent}{{");
 		sb.AppendLine($"{bodyIndent}{className} clone = new {className}();");
 
-		foreach (PropertyInfo property in properties)
+		foreach (PropertyDescriptor property in properties)
 			sb.AppendLine($"{bodyIndent}clone.{property.Name} = this.{property.Name};");
 
 		sb.AppendLine($"{bodyIndent}return clone;");
 		sb.AppendLine($"{indent}}}");
 	}
 
-	private static void AppendDeepCloneMethod(StringBuilder sb, string className, ImmutableArray<PropertyInfo> properties, int indentLevel)
+	private static void AppendDeepCloneMethod(StringBuilder sb, string className, ImmutableArray<PropertyDescriptor> properties, int indentLevel)
 	{
 		string indent = new(' ', indentLevel * 2);
 		string bodyIndent = new(' ', (indentLevel + 1) * 2);
@@ -150,7 +151,7 @@ public sealed class CloneableGenerator : IIncrementalGenerator
 		sb.AppendLine($"{indent}{{");
 		sb.AppendLine($"{bodyIndent}{className} clone = new {className}();");
 
-		foreach (PropertyInfo property in properties)
+		foreach (PropertyDescriptor property in properties)
 		{
 			if (property.IsCloneable)
 			{
@@ -174,49 +175,5 @@ public sealed class CloneableGenerator : IIncrementalGenerator
 		sb.AppendLine($"{indent}/// <inheritdoc/>");
 		sb.AppendLine($"{indent}object ICloneable.Clone()");
 		sb.AppendLine($"{bodyIndent}=> DeepClone();");
-	}
-
-	private static ImmutableArray<PropertyInfo> GetPublicProperties(INamedTypeSymbol classSymbol, HashSet<string> excludedProperties)
-	{
-		ImmutableArray<PropertyInfo>.Builder builder = ImmutableArray.CreateBuilder<PropertyInfo>();
-
-		foreach (ISymbol member in classSymbol.GetMembers())
-		{
-			if (member is not IPropertySymbol propertySymbol)
-				continue;
-
-			if (propertySymbol.DeclaredAccessibility != Accessibility.Public)
-				continue;
-
-			if (propertySymbol.IsStatic || propertySymbol.IsReadOnly || propertySymbol.IsWriteOnly)
-				continue;
-
-			if (propertySymbol.GetMethod is null || propertySymbol.SetMethod is null)
-				continue;
-
-			if (excludedProperties.Contains(propertySymbol.Name))
-				continue;
-
-			bool isCloneable = HasGenerateCloneableAttribute(propertySymbol.Type);
-
-			builder.Add(new PropertyInfo(propertySymbol.Name, isCloneable));
-		}
-
-		return builder.ToImmutable();
-	}
-
-	private static bool HasGenerateCloneableAttribute(ITypeSymbol typeSymbol)
-	{
-		foreach (AttributeData attributeData in typeSymbol.GetAttributes())
-			if (attributeData.AttributeClass?.ToDisplayString() == GeneratorAttributeName)
-				return true;
-
-		return false;
-	}
-
-	private readonly struct PropertyInfo(string name, bool isCloneable)
-	{
-		public string Name { get; } = name;
-		public bool IsCloneable { get; } = isCloneable;
 	}
 }

--- a/src/BB84.SourceGenerators/EqualityGenerator.cs
+++ b/src/BB84.SourceGenerators/EqualityGenerator.cs
@@ -9,6 +9,7 @@ using System.Text;
 using BB84.SourceGenerators.Attributes;
 using BB84.SourceGenerators.Extensions;
 using BB84.SourceGenerators.Helpers;
+using BB84.SourceGenerators.Models;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -59,7 +60,7 @@ public sealed class EqualityGenerator : IIncrementalGenerator
 		string accessibility = GeneratorHelpers.GetAccessibility(classDeclaration);
 
 		HashSet<string> excludedProperties = GeneratorHelpers.GetExcludedProperties(classDeclaration, semanticModel, "GenerateEquality", "GenerateEqualityAttribute");
-		ImmutableArray<PropertyInfo> properties = GetPublicProperties(classSymbol, excludedProperties);
+		ImmutableArray<PropertyDescriptor> properties = GeneratorHelpers.GetPropertyDescriptors(classSymbol, excludedProperties);
 
 		List<(string Accessibility, string Name)> outerClasses = GeneratorHelpers.GetOuterClasses(classDeclaration);
 
@@ -99,7 +100,7 @@ public sealed class EqualityGenerator : IIncrementalGenerator
 		context.AddSource(hintName, sb.ToString());
 	}
 
-	private static void AppendPartialClass(StringBuilder sb, string className, string accessibility, ImmutableArray<PropertyInfo> properties, int indentLevel = 1)
+	private static void AppendPartialClass(StringBuilder sb, string className, string accessibility, ImmutableArray<PropertyDescriptor> properties, int indentLevel = 1)
 	{
 		string indent = new(' ', indentLevel * 2);
 
@@ -129,7 +130,7 @@ public sealed class EqualityGenerator : IIncrementalGenerator
 		sb.AppendLine($"{bodyIndent}=> Equals(obj as {className});");
 	}
 
-	private static void AppendEqualsT(StringBuilder sb, string className, ImmutableArray<PropertyInfo> properties, int indentLevel)
+	private static void AppendEqualsT(StringBuilder sb, string className, ImmutableArray<PropertyDescriptor> properties, int indentLevel)
 	{
 		string indent = new(' ', indentLevel * 2);
 		string bodyIndent = new(' ', (indentLevel + 1) * 2);
@@ -171,7 +172,7 @@ public sealed class EqualityGenerator : IIncrementalGenerator
 		sb.AppendLine($"{indent}}}");
 	}
 
-	private static void AppendGetHashCode(StringBuilder sb, ImmutableArray<PropertyInfo> properties, int indentLevel)
+	private static void AppendGetHashCode(StringBuilder sb, ImmutableArray<PropertyDescriptor> properties, int indentLevel)
 	{
 		string indent = new(' ', indentLevel * 2);
 		string bodyIndent = new(' ', (indentLevel + 1) * 2);
@@ -191,7 +192,7 @@ public sealed class EqualityGenerator : IIncrementalGenerator
 			sb.AppendLine($"{bodyIndent}{{");
 			sb.AppendLine($"{deepIndent}int hash = 17;");
 
-			foreach (PropertyInfo property in properties)
+			foreach (PropertyDescriptor property in properties)
 			{
 				if (property.IsValueType)
 					sb.AppendLine($"{deepIndent}hash = hash * 31 + {property.Name}.GetHashCode();");
@@ -228,37 +229,5 @@ public sealed class EqualityGenerator : IIncrementalGenerator
 		sb.AppendLine($"{indent}/// </summary>");
 		sb.AppendLine($"{indent}public static bool operator !=({className}? left, {className}? right)");
 		sb.AppendLine($"{bodyIndent}=> !Equals(left, right);");
-	}
-
-	private static ImmutableArray<PropertyInfo> GetPublicProperties(INamedTypeSymbol classSymbol, HashSet<string> excludedProperties)
-	{
-		ImmutableArray<PropertyInfo>.Builder builder = ImmutableArray.CreateBuilder<PropertyInfo>();
-
-		foreach (ISymbol member in classSymbol.GetMembers())
-		{
-			if (member is not IPropertySymbol propertySymbol)
-				continue;
-
-			if (propertySymbol.DeclaredAccessibility != Accessibility.Public)
-				continue;
-
-			if (propertySymbol.IsStatic || propertySymbol.IsWriteOnly || propertySymbol.GetMethod is null)
-				continue;
-
-			if (excludedProperties.Contains(propertySymbol.Name))
-				continue;
-
-			bool isValueType = propertySymbol.Type.IsValueType
-				&& propertySymbol.Type.OriginalDefinition.SpecialType != SpecialType.System_Nullable_T;
-			builder.Add(new PropertyInfo(propertySymbol.Name, isValueType));
-		}
-
-		return builder.ToImmutable();
-	}
-
-	private readonly struct PropertyInfo(string name, bool isValueType)
-	{
-		public string Name { get; } = name;
-		public bool IsValueType { get; } = isValueType;
 	}
 }

--- a/src/BB84.SourceGenerators/Extensions/BaseTypeDeclarationSyntaxExtensions.cs
+++ b/src/BB84.SourceGenerators/Extensions/BaseTypeDeclarationSyntaxExtensions.cs
@@ -30,9 +30,9 @@ internal static class BaseTypeDeclarationSyntaxExtensions
 		SyntaxNode? potentialNamespaceParent = syntax.Parent;
 		// Keep moving "out" of nested classes etc until we get to a namespace
 		// or until we run out of parents
-		while (potentialNamespaceParent != null
-			&& potentialNamespaceParent is not NamespaceDeclarationSyntax
-			&& potentialNamespaceParent is not FileScopedNamespaceDeclarationSyntax)
+		while (potentialNamespaceParent is not null
+			and not NamespaceDeclarationSyntax
+			and not FileScopedNamespaceDeclarationSyntax)
 		{
 			potentialNamespaceParent = potentialNamespaceParent.Parent;
 		}

--- a/src/BB84.SourceGenerators/Helpers/GeneratorHelpers.cs
+++ b/src/BB84.SourceGenerators/Helpers/GeneratorHelpers.cs
@@ -3,6 +3,11 @@
 //
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
+using System.Collections.Immutable;
+
+using BB84.SourceGenerators.Extensions;
+using BB84.SourceGenerators.Models;
+
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -85,7 +90,11 @@ internal static class GeneratorHelpers
 	/// <param name="attributeShortName">The short name of the attribute (e.g., "GenerateToString").</param>
 	/// <param name="attributeFullName">The full name of the attribute (e.g., "GenerateToStringAttribute").</param>
 	/// <returns>A set of excluded property names.</returns>
-	internal static HashSet<string> GetExcludedProperties(ClassDeclarationSyntax classDeclaration, SemanticModel semanticModel, string attributeShortName, string attributeFullName)
+	internal static HashSet<string> GetExcludedProperties(
+		ClassDeclarationSyntax classDeclaration,
+		SemanticModel semanticModel,
+		string attributeShortName,
+		string attributeFullName)
 	{
 		HashSet<string> excluded = new(StringComparer.Ordinal);
 
@@ -137,4 +146,71 @@ internal static class GeneratorHelpers
 	/// <returns>A tuple of class declaration syntax and semantic model, or null if the target node is not a class declaration.</returns>
 	internal static (ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)? TransformClassSyntax(GeneratorAttributeSyntaxContext context)
 		=> context.TargetNode is not ClassDeclarationSyntax classSyntax ? null : ((ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)?)(classSyntax, context.SemanticModel);
+
+	/// <summary>
+	/// Gets all public readable properties from the given class symbol, optionally excluding specific properties.
+	/// Properties must be public, non-static, and have a getter.
+	/// </summary>
+	/// <param name="classSymbol">The class symbol to inspect.</param>
+	/// <param name="excludedProperties">Optional set of property names to exclude.</param>
+	/// <param name="requireSetter">When <see langword="true"/>, only includes properties that also have a public setter.</param>
+	/// <param name="cloneableAttributeName">
+	/// When not <see langword="null"/>, checks whether the property type is decorated with the specified attribute
+	/// and sets <see cref="PropertyDescriptor.IsCloneable"/> accordingly.
+	/// </param>
+	/// <returns>An immutable array of <see cref="PropertyDescriptor"/> instances.</returns>
+	internal static ImmutableArray<PropertyDescriptor> GetPropertyDescriptors(
+		INamedTypeSymbol classSymbol,
+		HashSet<string>? excludedProperties = null,
+		bool requireSetter = false,
+		string? cloneableAttributeName = null)
+	{
+		ImmutableArray<PropertyDescriptor>.Builder builder = ImmutableArray.CreateBuilder<PropertyDescriptor>();
+
+		foreach (ISymbol member in classSymbol.GetMembers())
+		{
+			if (member is not IPropertySymbol propertySymbol)
+				continue;
+
+			if (propertySymbol.DeclaredAccessibility != Accessibility.Public)
+				continue;
+
+			if (propertySymbol.IsStatic || propertySymbol.IsWriteOnly || propertySymbol.GetMethod is null)
+				continue;
+
+			if (requireSetter)
+			{
+				if (propertySymbol.IsReadOnly || propertySymbol.SetMethod is null)
+					continue;
+
+				if (propertySymbol.SetMethod.DeclaredAccessibility != Accessibility.Public)
+					continue;
+			}
+
+			if (excludedProperties is not null && excludedProperties.Contains(propertySymbol.Name))
+				continue;
+
+			bool isValueType = propertySymbol.Type.IsValueType
+				&& propertySymbol.Type.OriginalDefinition.SpecialType != SpecialType.System_Nullable_T;
+			bool isNullable = propertySymbol.NullableAnnotation == NullableAnnotation.Annotated;
+			string typeName = propertySymbol.Type.ToFullyQualifiedDisplayString();
+
+			bool isCloneable = false;
+			if (cloneableAttributeName is not null)
+			{
+				foreach (AttributeData attributeData in propertySymbol.Type.GetAttributes())
+				{
+					if (attributeData.AttributeClass?.ToDisplayString() == cloneableAttributeName)
+					{
+						isCloneable = true;
+						break;
+					}
+				}
+			}
+
+			builder.Add(new PropertyDescriptor(propertySymbol.Name, typeName, isValueType, isNullable, isCloneable));
+		}
+
+		return builder.ToImmutable();
+	}
 }

--- a/src/BB84.SourceGenerators/Models/PropertyDescriptor.cs
+++ b/src/BB84.SourceGenerators/Models/PropertyDescriptor.cs
@@ -1,0 +1,44 @@
+// Copyright: 2026 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+namespace BB84.SourceGenerators.Models;
+
+/// <summary>
+/// Describes a property discovered during source generation, carrying metadata
+/// needed by multiple generators (Equality, Cloneable, Builder, ToString).
+/// </summary>
+internal sealed record PropertyDescriptor(string Name, string TypeName, bool IsValueType, bool IsNullable, bool IsCloneable)
+{
+	/// <summary>
+	/// Gets the name of the property.
+	/// </summary>
+	public string Name { get; } = Name;
+
+	/// <summary>
+	/// Gets the fully qualified type name of the property.
+	/// </summary>
+	public string TypeName { get; } = TypeName;
+
+	/// <summary>
+	/// Gets a value indicating whether the property type is a value type.
+	/// </summary>
+	public bool IsValueType { get; } = IsValueType;
+
+	/// <summary>
+	/// Gets a value indicating whether the property type is a reference type.
+	/// </summary>
+	public bool IsReferenceType => !IsValueType;
+
+	/// <summary>
+	/// Gets a value indicating whether the property is nullable.
+	/// </summary>
+	public bool IsNullable { get; } = IsNullable;
+
+	/// <summary>
+	/// Gets a value indicating whether the property type is marked with
+	/// <c>[GenerateCloneable]</c> and supports deep cloning.
+	/// </summary>
+	public bool IsCloneable { get; } = IsCloneable;
+}

--- a/src/BB84.SourceGenerators/ToStringGenerator.cs
+++ b/src/BB84.SourceGenerators/ToStringGenerator.cs
@@ -9,6 +9,7 @@ using System.Text;
 using BB84.SourceGenerators.Attributes;
 using BB84.SourceGenerators.Extensions;
 using BB84.SourceGenerators.Helpers;
+using BB84.SourceGenerators.Models;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -57,7 +58,7 @@ public sealed class ToStringGenerator : IIncrementalGenerator
 		string accessibility = GeneratorHelpers.GetAccessibility(classDeclaration);
 
 		HashSet<string> excludedProperties = GeneratorHelpers.GetExcludedProperties(classDeclaration, semanticModel, "GenerateToString", "GenerateToStringAttribute");
-		ImmutableArray<string> properties = GetPublicProperties(classSymbol, excludedProperties);
+		ImmutableArray<PropertyDescriptor> properties = GeneratorHelpers.GetPropertyDescriptors(classSymbol, excludedProperties);
 
 		List<(string Accessibility, string Name)> outerClasses = GeneratorHelpers.GetOuterClasses(classDeclaration);
 
@@ -96,7 +97,7 @@ public sealed class ToStringGenerator : IIncrementalGenerator
 		context.AddSource(hintName, sb.ToString());
 	}
 
-	private static void AppendPartialClass(StringBuilder sb, string className, string accessibility, ImmutableArray<string> properties, int indentLevel = 1)
+	private static void AppendPartialClass(StringBuilder sb, string className, string accessibility, ImmutableArray<PropertyDescriptor> properties, int indentLevel = 1)
 	{
 		string indent = new(' ', indentLevel * 2);
 		string innerIndent = new(' ', (indentLevel + 1) * 2);
@@ -117,7 +118,7 @@ public sealed class ToStringGenerator : IIncrementalGenerator
 		sb.AppendLine($"{indent}}}");
 	}
 
-	private static string BuildFormatString(ImmutableArray<string> properties)
+	private static string BuildFormatString(ImmutableArray<PropertyDescriptor> properties)
 	{
 		StringBuilder format = new();
 
@@ -126,33 +127,9 @@ public sealed class ToStringGenerator : IIncrementalGenerator
 			if (i > 0)
 				format.Append(", ");
 
-			format.Append($"{properties[i]} = {{{properties[i]}}}");
+			format.Append($"{properties[i].Name} = {{{properties[i].Name}}}");
 		}
 
 		return format.ToString();
-	}
-
-	private static ImmutableArray<string> GetPublicProperties(INamedTypeSymbol classSymbol, HashSet<string> excludedProperties)
-	{
-		ImmutableArray<string>.Builder builder = ImmutableArray.CreateBuilder<string>();
-
-		foreach (ISymbol member in classSymbol.GetMembers())
-		{
-			if (member is not IPropertySymbol propertySymbol)
-				continue;
-
-			if (propertySymbol.DeclaredAccessibility != Accessibility.Public)
-				continue;
-
-			if (propertySymbol.IsStatic || propertySymbol.IsWriteOnly || propertySymbol.GetMethod is null)
-				continue;
-
-			if (excludedProperties.Contains(propertySymbol.Name))
-				continue;
-
-			builder.Add(propertySymbol.Name);
-		}
-
-		return builder.ToImmutable();
 	}
 }


### PR DESCRIPTION
**Changes:**

- Shared PropertyDescriptor record was created at `src/BB84.SourceGenerators/Models/PropertyDescriptor.cs` with fields: `Name`, `TypeName`, `IsValueType`, `IsNullable`, `IsCloneable`, and a computed `IsReferenceType` property.
- All three previously-duplicated `PropertyInfo` records (from `CloneableGenerator`, `EqualityGenerator`, and `BuilderGenerator`) have been removed and replaced with the shared `PropertyDescriptor`.
- A shared `GetPropertyDescriptors` helper was added to `GeneratorHelpers` to centralize property collection.

closes #87 