### PR TITLE
feat: Refactored hardcoded attribute name strings

### DIFF
--- a/src/BB84.SourceGenerators/CloneableGenerator.cs
+++ b/src/BB84.SourceGenerators/CloneableGenerator.cs
@@ -48,7 +48,7 @@ public sealed class CloneableGenerator : IIncrementalGenerator
 		if (!GeneratorHelpers.TryCreateContext(input, out GeneratorContext ctx))
 			return;
 
-		HashSet<string> excludedProperties = GeneratorHelpers.GetExcludedProperties(ctx.ClassDeclaration, ctx.SemanticModel, "GenerateCloneable", "GenerateCloneableAttribute");
+		HashSet<string> excludedProperties = GeneratorHelpers.GetExcludedProperties(ctx.ClassDeclaration, ctx.SemanticModel, nameof(GenerateCloneableAttribute));
 		ImmutableArray<PropertyDescriptor> properties = GeneratorHelpers.GetPropertyDescriptors(ctx.ClassSymbol, excludedProperties, requireSetter: true, cloneableAttributeName: GeneratorAttributeName);
 
 		StringBuilder sb = new();

--- a/src/BB84.SourceGenerators/DisposableGenerator.cs
+++ b/src/BB84.SourceGenerators/DisposableGenerator.cs
@@ -27,10 +27,10 @@ public sealed class DisposableGenerator : IIncrementalGenerator
 {
 	private static readonly string GeneratorName = typeof(DisposableGenerator).FullName;
 	private static readonly string GeneratorAttributeName = typeof(GenerateDisposableAttribute).FullName;
-	private const string AttributeShortName = "GenerateDisposable";
-	private const string AttributeFullName = "GenerateDisposableAttribute";
-	private const string DisposeResourceShortName = "DisposeResource";
-	private const string DisposeResourceFullName = "DisposeResourceAttribute";
+	private const string AttributeFullName = nameof(GenerateDisposableAttribute);
+	private static readonly string AttributeShortName = GeneratorHelpers.StripAttributeSuffix(AttributeFullName);
+	private const string DisposeResourceFullName = nameof(DisposeResourceAttribute);
+	private static readonly string DisposeResourceShortName = GeneratorHelpers.StripAttributeSuffix(DisposeResourceFullName);
 
 	/// <inheritdoc/>
 	public void Initialize(IncrementalGeneratorInitializationContext context)
@@ -136,7 +136,7 @@ public sealed class DisposableGenerator : IIncrementalGenerator
 			{
 				string name = attribute.Name.ToString();
 
-				if (name is not AttributeShortName and not AttributeFullName)
+				if (name != AttributeShortName && name != AttributeFullName)
 					continue;
 
 				if (attribute.ArgumentList is null || attribute.ArgumentList.Arguments.Count == 0)
@@ -222,7 +222,7 @@ public sealed class DisposableGenerator : IIncrementalGenerator
 			{
 				string name = attribute.Name.ToString();
 
-				if (name is not DisposeResourceShortName and not DisposeResourceFullName)
+				if (name != DisposeResourceShortName && name != DisposeResourceFullName)
 					continue;
 
 				if (attribute.ArgumentList is null || attribute.ArgumentList.Arguments.Count == 0)

--- a/src/BB84.SourceGenerators/EqualityGenerator.cs
+++ b/src/BB84.SourceGenerators/EqualityGenerator.cs
@@ -47,7 +47,7 @@ public sealed class EqualityGenerator : IIncrementalGenerator
 		if (!GeneratorHelpers.TryCreateContext(input, out GeneratorContext ctx))
 			return;
 
-		HashSet<string> excludedProperties = GeneratorHelpers.GetExcludedProperties(ctx.ClassDeclaration, ctx.SemanticModel, "GenerateEquality", "GenerateEqualityAttribute");
+		HashSet<string> excludedProperties = GeneratorHelpers.GetExcludedProperties(ctx.ClassDeclaration, ctx.SemanticModel, nameof(GenerateEqualityAttribute));
 		ImmutableArray<PropertyDescriptor> properties = GeneratorHelpers.GetPropertyDescriptors(ctx.ClassSymbol, excludedProperties);
 
 		StringBuilder sb = new();

--- a/src/BB84.SourceGenerators/Helpers/GeneratorHelpers.cs
+++ b/src/BB84.SourceGenerators/Helpers/GeneratorHelpers.cs
@@ -19,6 +19,7 @@ namespace BB84.SourceGenerators.Helpers;
 /// </summary>
 internal static class GeneratorHelpers
 {
+	private const string AttributeKeyword = "Attribute";
 	private const string PublicKeyword = "public";
 	private const string InternalKeyword = "internal";
 	private const string ProtectedKeyword = "protected";
@@ -87,15 +88,14 @@ internal static class GeneratorHelpers
 	/// </summary>
 	/// <param name="classDeclaration">The class declaration syntax.</param>
 	/// <param name="semanticModel">The semantic model.</param>
-	/// <param name="attributeShortName">The short name of the attribute (e.g., "GenerateToString").</param>
 	/// <param name="attributeFullName">The full name of the attribute (e.g., "GenerateToStringAttribute").</param>
 	/// <returns>A set of excluded property names.</returns>
 	internal static HashSet<string> GetExcludedProperties(
 		ClassDeclarationSyntax classDeclaration,
 		SemanticModel semanticModel,
-		string attributeShortName,
 		string attributeFullName)
 	{
+		string attributeShortName = StripAttributeSuffix(attributeFullName);
 		HashSet<string> excluded = new(StringComparer.Ordinal);
 
 		foreach (AttributeListSyntax attributeList in classDeclaration.AttributeLists)
@@ -122,6 +122,16 @@ internal static class GeneratorHelpers
 
 		return excluded;
 	}
+
+	/// <summary>
+	/// Strips the "Attribute" suffix from an attribute type name.
+	/// </summary>
+	/// <param name="attributeName">The full attribute name (e.g., "GenerateToStringAttribute").</param>
+	/// <returns>The attribute name without the "Attribute" suffix (e.g., "GenerateToString").</returns>
+	internal static string StripAttributeSuffix(string attributeName)
+		=> attributeName.EndsWith(AttributeKeyword, StringComparison.Ordinal)
+			? attributeName[..^AttributeKeyword.Length]
+			: attributeName;
 
 	/// <summary>
 	/// Escapes a string for use in a regular string literal.

--- a/src/BB84.SourceGenerators/IniFileGenerator.cs
+++ b/src/BB84.SourceGenerators/IniFileGenerator.cs
@@ -29,6 +29,8 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 	private static readonly string GeneratorAttributeName = typeof(GenerateIniFileAttribute).FullName;
 	private static readonly string SectionAttributeName = typeof(GenerateIniFileSectionAttribute).FullName;
 	private static readonly string ValueAttributeName = typeof(GenerateIniFileValueAttribute).FullName;
+	private const string AttributeFullName = nameof(GenerateIniFileAttribute);
+	private static readonly string AttributeShortName = GeneratorHelpers.StripAttributeSuffix(AttributeFullName);
 	private static readonly string[] LineBreakSeparators = ["\r\n", "\n"];
 
 	/// <inheritdoc/>
@@ -564,7 +566,7 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 			{
 				string name = attribute.Name.ToString();
 
-				if (name is not "GenerateIniFile" and not "GenerateIniFileAttribute")
+				if (name != AttributeShortName && name != AttributeFullName)
 					continue;
 
 				if (attribute.ArgumentList is null)

--- a/src/BB84.SourceGenerators/NotificationsGenerator.cs
+++ b/src/BB84.SourceGenerators/NotificationsGenerator.cs
@@ -24,8 +24,8 @@ public sealed class NotificationsGenerator : IIncrementalGenerator
 {
 	private static readonly string GeneratorName = typeof(NotificationsGenerator).FullName;
 	private static readonly string GeneratorAttributeName = typeof(GenerateNotificationsAttribute).FullName;
-	private const string AttributeShortName = "GenerateNotifications";
-	private const string AttributeFullName = "GenerateNotificationsAttribute";
+	private const string AttributeFullName = nameof(GenerateNotificationsAttribute);
+	private static readonly string AttributeShortName = GeneratorHelpers.StripAttributeSuffix(AttributeFullName);
 
 	/// <inheritdoc/>
 	public void Initialize(IncrementalGeneratorInitializationContext context)
@@ -118,7 +118,7 @@ public sealed class NotificationsGenerator : IIncrementalGenerator
 			{
 				string name = attribute.Name.ToString();
 
-				if (name is not AttributeShortName and not AttributeFullName)
+				if (name != AttributeShortName && name != AttributeFullName)
 					continue;
 
 				if (attribute.ArgumentList is null || attribute.ArgumentList.Arguments.Count == 0)

--- a/src/BB84.SourceGenerators/SingletonGenerator.cs
+++ b/src/BB84.SourceGenerators/SingletonGenerator.cs
@@ -23,8 +23,8 @@ namespace BB84.SourceGenerators;
 [Generator(LanguageNames.CSharp)]
 public sealed class SingletonGenerator : IIncrementalGenerator
 {
-	private const string AttributeShortName = "GenerateSingleton";
-	private const string AttributeFullName = "GenerateSingletonAttribute";
+	private const string AttributeFullName = nameof(GenerateSingletonAttribute);
+	private static readonly string AttributeShortName = GeneratorHelpers.StripAttributeSuffix(AttributeFullName);
 	private static readonly string GeneratorName = typeof(SingletonGenerator).FullName;
 	private static readonly string GeneratorAttributeName = typeof(GenerateSingletonAttribute).FullName;
 
@@ -155,7 +155,7 @@ public sealed class SingletonGenerator : IIncrementalGenerator
 			{
 				string name = attribute.Name.ToString();
 
-				if (name is not AttributeShortName and not AttributeFullName)
+				if (name != AttributeShortName && name != AttributeFullName)
 					continue;
 
 				if (attribute.ArgumentList is null || attribute.ArgumentList.Arguments.Count == 0)

--- a/src/BB84.SourceGenerators/ToStringGenerator.cs
+++ b/src/BB84.SourceGenerators/ToStringGenerator.cs
@@ -45,7 +45,7 @@ public sealed class ToStringGenerator : IIncrementalGenerator
 		if (!GeneratorHelpers.TryCreateContext(input, out GeneratorContext ctx))
 			return;
 
-		HashSet<string> excludedProperties = GeneratorHelpers.GetExcludedProperties(ctx.ClassDeclaration, ctx.SemanticModel, "GenerateToString", "GenerateToStringAttribute");
+		HashSet<string> excludedProperties = GeneratorHelpers.GetExcludedProperties(ctx.ClassDeclaration, ctx.SemanticModel, nameof(GenerateToStringAttribute));
 		ImmutableArray<PropertyDescriptor> properties = GeneratorHelpers.GetPropertyDescriptors(ctx.ClassSymbol, excludedProperties);
 
 		StringBuilder sb = new();


### PR DESCRIPTION
**Changes:**

- Added `StripAttributeSuffix` helper to `GeneratorHelpers` that strips the "Attribute" suffix from an attribute type name.
- Simplified `GetExcludedProperties` — it now takes only the full attribute name and derives the short name internally. Callers (`ToStringGenerator`, `EqualityGenerator`, `CloneableGenerator`) now pass `nameof(GenerateXxxAttribute)` instead of two separate string literals.
- Replaced hardcoded string constants in `DisposableGenerator`, `NotificationsGenerator`, `SingletonGenerator`, and `IniFileGenerator` with `nameof()`-derived values:
  - `AttributeFullName` uses `nameof(GenerateXxxAttribute)` (compile-time constant)
  - `AttributeShortName` uses `GeneratorHelpers.StripAttributeSuffix(AttributeFullName)` (runtime-derived from the single source of truth)
- Updated pattern matching from is not ... and not ... (requires constants) to `!=` ... `&& !=` ... (works with readonly fields).

closes #94 