### PR TITLE
feat: refactored the duplicated property collection logic

### DIFF
--- a/src/BB84.SourceGenerators/AutoMapperGenerator.cs
+++ b/src/BB84.SourceGenerators/AutoMapperGenerator.cs
@@ -223,31 +223,10 @@ public sealed class AutoMapperGenerator : IIncrementalGenerator
 	}
 
 	private static IEnumerable<IPropertySymbol> GetSettableProperties(ITypeSymbol type)
-	{
-		return GetAllProperties(type)
-			.Where(p => p.SetMethod is not null && p.DeclaredAccessibility == Accessibility.Public);
-	}
+		=> GeneratorHelpers.GetPublicPropertySymbols(type, includeInherited: true, requireGetter: false, requireSetter: true);
 
 	private static IEnumerable<IPropertySymbol> GetReadableProperties(ITypeSymbol type)
-	{
-		return GetAllProperties(type)
-			.Where(p => p.GetMethod is not null && p.DeclaredAccessibility == Accessibility.Public);
-	}
-
-	private static IEnumerable<IPropertySymbol> GetAllProperties(ITypeSymbol type)
-	{
-		ITypeSymbol? current = type;
-		while (current is not null)
-		{
-			foreach (ISymbol member in current.GetMembers())
-			{
-				if (member is IPropertySymbol property && !property.IsIndexer && !property.IsStatic)
-					yield return property;
-			}
-
-			current = current.BaseType;
-		}
-	}
+		=> GeneratorHelpers.GetPublicPropertySymbols(type, includeInherited: true, requireGetter: true, requireSetter: false);
 
 	private void Execute(SourceProductionContext context, AutoMapperRequest? request)
 	{

--- a/src/BB84.SourceGenerators/Helpers/GeneratorHelpers.cs
+++ b/src/BB84.SourceGenerators/Helpers/GeneratorHelpers.cs
@@ -209,25 +209,10 @@ internal static class GeneratorHelpers
 	{
 		ImmutableArray<PropertyDescriptor>.Builder builder = ImmutableArray.CreateBuilder<PropertyDescriptor>();
 
-		foreach (ISymbol member in classSymbol.GetMembers())
+		foreach (IPropertySymbol propertySymbol in GetPublicPropertySymbols(classSymbol, requireGetter: true, requireSetter: requireSetter))
 		{
-			if (member is not IPropertySymbol propertySymbol)
+			if (propertySymbol.IsWriteOnly)
 				continue;
-
-			if (propertySymbol.DeclaredAccessibility != Accessibility.Public)
-				continue;
-
-			if (propertySymbol.IsStatic || propertySymbol.IsWriteOnly || propertySymbol.GetMethod is null)
-				continue;
-
-			if (requireSetter)
-			{
-				if (propertySymbol.IsReadOnly || propertySymbol.SetMethod is null)
-					continue;
-
-				if (propertySymbol.SetMethod.DeclaredAccessibility != Accessibility.Public)
-					continue;
-			}
 
 			if (excludedProperties is not null && excludedProperties.Contains(propertySymbol.Name))
 				continue;
@@ -254,5 +239,49 @@ internal static class GeneratorHelpers
 		}
 
 		return builder.ToImmutable();
+	}
+
+	/// <summary>
+	/// Enumerates public, non-static, non-indexer property symbols from the given type,
+	/// optionally walking the inheritance hierarchy.
+	/// </summary>
+	/// <param name="typeSymbol">The type symbol to inspect.</param>
+	/// <param name="includeInherited">When <see langword="true"/>, also includes properties from base types (excluding <see cref="object"/>).</param>
+	/// <param name="requireGetter">When <see langword="true"/>, only includes properties with a getter.</param>
+	/// <param name="requireSetter">When <see langword="true"/>, only includes properties with a public setter.</param>
+	/// <returns>An enumerable of matching <see cref="IPropertySymbol"/> instances.</returns>
+	internal static IEnumerable<IPropertySymbol> GetPublicPropertySymbols(
+		ITypeSymbol typeSymbol,
+		bool includeInherited = false,
+		bool requireGetter = true,
+		bool requireSetter = false)
+	{
+		ITypeSymbol? current = typeSymbol;
+
+		do
+		{
+			foreach (ISymbol member in current.GetMembers())
+			{
+				if (member is not IPropertySymbol propertySymbol)
+					continue;
+
+				if (propertySymbol.DeclaredAccessibility != Accessibility.Public)
+					continue;
+
+				if (propertySymbol.IsStatic || propertySymbol.IsIndexer)
+					continue;
+
+				if (requireGetter && propertySymbol.GetMethod is null)
+					continue;
+
+				if (requireSetter && (propertySymbol.SetMethod is null || propertySymbol.SetMethod.DeclaredAccessibility != Accessibility.Public))
+					continue;
+
+				yield return propertySymbol;
+			}
+
+			current = includeInherited ? current.BaseType : null;
+		}
+		while (current is not null && current.SpecialType != SpecialType.System_Object);
 	}
 }

--- a/src/BB84.SourceGenerators/ValidatorGenerator.cs
+++ b/src/BB84.SourceGenerators/ValidatorGenerator.cs
@@ -257,29 +257,8 @@ public sealed class ValidatorGenerator : IIncrementalGenerator
 		ImmutableArray<PropertyValidationInfo>.Builder builder = ImmutableArray.CreateBuilder<PropertyValidationInfo>();
 		HashSet<string> seen = [];
 
-		INamedTypeSymbol? currentType = classSymbol;
-		while (currentType is not null && currentType.SpecialType != SpecialType.System_Object)
+		foreach (IPropertySymbol propertySymbol in GeneratorHelpers.GetPublicPropertySymbols(classSymbol, includeInherited: true, requireGetter: true))
 		{
-			CollectValidatedProperties(currentType, builder, seen);
-			currentType = currentType.BaseType;
-		}
-
-		return builder.ToImmutable();
-	}
-
-	private static void CollectValidatedProperties(INamedTypeSymbol typeSymbol, ImmutableArray<PropertyValidationInfo>.Builder builder, HashSet<string> seen)
-	{
-		foreach (ISymbol member in typeSymbol.GetMembers())
-		{
-			if (member is not IPropertySymbol propertySymbol)
-				continue;
-
-			if (propertySymbol.DeclaredAccessibility != Accessibility.Public)
-				continue;
-
-			if (propertySymbol.IsStatic || propertySymbol.GetMethod is null)
-				continue;
-
 			if (!seen.Add(propertySymbol.Name))
 				continue;
 
@@ -315,6 +294,8 @@ public sealed class ValidatorGenerator : IIncrementalGenerator
 				builder.Add(new PropertyValidationInfo(propertySymbol.Name, typeName, isCollection, isArray, rules.ToImmutable()));
 			}
 		}
+
+		return builder.ToImmutable();
 	}
 
 	private static ValidationRule ParseRequiredAttribute(AttributeData attribute)


### PR DESCRIPTION
**Changes:**

1. Added `GetPublicPropertySymbols` helper to `GeneratorHelpers` — a reusable method that enumerates public, non-static, non-indexer `IPropertySymbol` instances with configurable options.
2. Refactored `GetPropertyDescriptors` to use `GetPublicPropertySymbols` internally, eliminating its own duplicate filtering logic.
3. Refactored `AutoMapperGenerator` - removed the private `GetAllProperties`, `GetSettableProperties`, and `GetReadableProperties` methods (27 lines), replaced with one-liner delegates to `GeneratorHelpers.GetPublicPropertySymbols`.
4. Refactored `ValidatorGenerator` - removed the separate `CollectValidatedProperties` method and manual inheritance loop, replaced with a single foreach over `GetPublicPropertySymbols(classSymbol, includeInherited: true, requireGetter: true)`.

closes #89 