### PR TITLE
feat: refactored generator init logic with shared helper method

### DIFF
--- a/src/BB84.SourceGenerators/AbstractionGenerator.cs
+++ b/src/BB84.SourceGenerators/AbstractionGenerator.cs
@@ -200,7 +200,7 @@ public sealed class AbstractionGenerator : IIncrementalGenerator
 	private static string CreateAbstractionPropertySignature(IPropertySymbol propertySymbol)
 	{
 		string accessors = GetPropertyAccessors(propertySymbol);
-		return $"{propertySymbol.Type} {propertySymbol.Name} {{ {accessors} }}";
+		return $"{propertySymbol.Type} {propertySymbol.Name} {{{accessors}}}";
 	}
 
 	/// <summary>
@@ -215,9 +215,9 @@ public sealed class AbstractionGenerator : IIncrementalGenerator
 			? $"get => {request.TargetType}.{propertySymbol.Name};"
 			: string.Empty;
 		string setter = propertySymbol.SetMethod != null && propertySymbol.SetMethod.DeclaredAccessibility == Accessibility.Public
-			? $"set => {request.TargetType}.{propertySymbol.Name} = value;"
+			? $" set => {request.TargetType}.{propertySymbol.Name} = value;"
 			: string.Empty;
-		return $"public {propertySymbol.Type} {propertySymbol.Name} {{{getter}{setter}}}";
+		return $"public {propertySymbol.Type} {propertySymbol.Name} {{ {getter}{setter} }}";
 	}
 
 	/// <summary>
@@ -228,12 +228,12 @@ public sealed class AbstractionGenerator : IIncrementalGenerator
 	private static string GetPropertyAccessors(IPropertySymbol propertySymbol)
 	{
 		string getter = propertySymbol.GetMethod != null && propertySymbol.GetMethod.DeclaredAccessibility == Accessibility.Public
-			? "get; "
+			? "get;"
 			: string.Empty;
 		string setter = propertySymbol.SetMethod != null && propertySymbol.SetMethod.DeclaredAccessibility == Accessibility.Public
-			? "set; "
+			? " set;"
 			: string.Empty;
-		return $" {getter}{setter}";
+		return $" {getter}{setter} ";
 	}
 
 	/// <summary>

--- a/src/BB84.SourceGenerators/AssemblyInformationGenerator.cs
+++ b/src/BB84.SourceGenerators/AssemblyInformationGenerator.cs
@@ -38,17 +38,7 @@ public sealed class AssemblyInformationGenerator : IIncrementalGenerator
 
 	/// <inheritdoc/>
 	public void Initialize(IncrementalGeneratorInitializationContext context)
-	{
-		IncrementalValuesProvider<(ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)?> provider =
-			context.SyntaxProvider
-				.ForAttributeWithMetadataName(
-					fullyQualifiedMetadataName: GeneratorAttributeName,
-					predicate: static (node, _) => node is ClassDeclarationSyntax,
-					transform: static (ctx, _) => GeneratorHelpers.TransformClassSyntax(ctx))
-				.Where(static result => result is not null);
-
-		context.RegisterSourceOutput(provider, Execute);
-	}
+		=> GeneratorHelpers.RegisterClassGenerator(context, GeneratorAttributeName, Execute);
 
 	private void Execute(SourceProductionContext context, (ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)? input)
 	{

--- a/src/BB84.SourceGenerators/BuilderGenerator.cs
+++ b/src/BB84.SourceGenerators/BuilderGenerator.cs
@@ -26,17 +26,7 @@ public sealed class BuilderGenerator : IIncrementalGenerator
 
 	/// <inheritdoc/>
 	public void Initialize(IncrementalGeneratorInitializationContext context)
-	{
-		IncrementalValuesProvider<(ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)?> provider =
-			context.SyntaxProvider
-				.ForAttributeWithMetadataName(
-					fullyQualifiedMetadataName: GeneratorAttributeName,
-					predicate: static (node, _) => node is ClassDeclarationSyntax,
-					transform: static (ctx, _) => GeneratorHelpers.TransformClassSyntax(ctx))
-				.Where(static result => result is not null);
-
-		context.RegisterSourceOutput(provider, Execute);
-	}
+		=> GeneratorHelpers.RegisterClassGenerator(context, GeneratorAttributeName, Execute);
 
 	private void Execute(SourceProductionContext context, (ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)? input)
 	{

--- a/src/BB84.SourceGenerators/CloneableGenerator.cs
+++ b/src/BB84.SourceGenerators/CloneableGenerator.cs
@@ -29,17 +29,7 @@ public sealed class CloneableGenerator : IIncrementalGenerator
 
 	/// <inheritdoc/>
 	public void Initialize(IncrementalGeneratorInitializationContext context)
-	{
-		IncrementalValuesProvider<(ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)?> provider =
-			context.SyntaxProvider
-				.ForAttributeWithMetadataName(
-					fullyQualifiedMetadataName: GeneratorAttributeName,
-					predicate: static (node, _) => node is ClassDeclarationSyntax,
-					transform: static (ctx, _) => GeneratorHelpers.TransformClassSyntax(ctx))
-				.Where(static result => result is not null);
-
-		context.RegisterSourceOutput(provider, Execute);
-	}
+		=> GeneratorHelpers.RegisterClassGenerator(context, GeneratorAttributeName, Execute);
 
 	private void Execute(SourceProductionContext context, (ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)? input)
 	{

--- a/src/BB84.SourceGenerators/DecoratorGenerator.cs
+++ b/src/BB84.SourceGenerators/DecoratorGenerator.cs
@@ -30,17 +30,7 @@ public sealed class DecoratorGenerator : IIncrementalGenerator
 
 	/// <inheritdoc/>
 	public void Initialize(IncrementalGeneratorInitializationContext context)
-	{
-		IncrementalValuesProvider<(ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)?> provider =
-			context.SyntaxProvider
-				.ForAttributeWithMetadataName(
-					fullyQualifiedMetadataName: GeneratorAttributeName,
-					predicate: static (node, _) => node is ClassDeclarationSyntax,
-					transform: static (ctx, _) => GeneratorHelpers.TransformClassSyntax(ctx))
-				.Where(static result => result is not null);
-
-		context.RegisterSourceOutput(provider, Execute);
-	}
+		=> GeneratorHelpers.RegisterClassGenerator(context, GeneratorAttributeName, Execute);
 
 	private void Execute(SourceProductionContext context, (ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)? input)
 	{

--- a/src/BB84.SourceGenerators/DisposableGenerator.cs
+++ b/src/BB84.SourceGenerators/DisposableGenerator.cs
@@ -32,17 +32,7 @@ public sealed class DisposableGenerator : IIncrementalGenerator
 
 	/// <inheritdoc/>
 	public void Initialize(IncrementalGeneratorInitializationContext context)
-	{
-		IncrementalValuesProvider<(ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)?> provider =
-			context.SyntaxProvider
-				.ForAttributeWithMetadataName(
-					fullyQualifiedMetadataName: GeneratorAttributeName,
-					predicate: static (node, _) => node is ClassDeclarationSyntax,
-					transform: static (ctx, _) => GeneratorHelpers.TransformClassSyntax(ctx))
-				.Where(static result => result is not null);
-
-		context.RegisterSourceOutput(provider, Execute);
-	}
+		=> GeneratorHelpers.RegisterClassGenerator(context, GeneratorAttributeName, Execute);
 
 	private void Execute(SourceProductionContext context, (ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)? input)
 	{

--- a/src/BB84.SourceGenerators/EqualityGenerator.cs
+++ b/src/BB84.SourceGenerators/EqualityGenerator.cs
@@ -29,17 +29,7 @@ public sealed class EqualityGenerator : IIncrementalGenerator
 
 	/// <inheritdoc/>
 	public void Initialize(IncrementalGeneratorInitializationContext context)
-	{
-		IncrementalValuesProvider<(ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)?> provider =
-			context.SyntaxProvider
-				.ForAttributeWithMetadataName(
-					fullyQualifiedMetadataName: GeneratorAttributeName,
-					predicate: static (node, _) => node is ClassDeclarationSyntax,
-					transform: static (ctx, _) => GeneratorHelpers.TransformClassSyntax(ctx))
-				.Where(static result => result is not null);
-
-		context.RegisterSourceOutput(provider, Execute);
-	}
+		=> GeneratorHelpers.RegisterClassGenerator(context, GeneratorAttributeName, Execute);
 
 	private void Execute(SourceProductionContext context, (ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)? input)
 	{

--- a/src/BB84.SourceGenerators/FactoryGenerator.cs
+++ b/src/BB84.SourceGenerators/FactoryGenerator.cs
@@ -29,17 +29,7 @@ public sealed class FactoryGenerator : IIncrementalGenerator
 
 	/// <inheritdoc/>
 	public void Initialize(IncrementalGeneratorInitializationContext context)
-	{
-		IncrementalValuesProvider<(ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)?> provider =
-			context.SyntaxProvider
-				.ForAttributeWithMetadataName(
-					fullyQualifiedMetadataName: GeneratorAttributeName,
-					predicate: static (node, _) => node is ClassDeclarationSyntax,
-					transform: static (ctx, _) => GeneratorHelpers.TransformClassSyntax(ctx))
-				.Where(static result => result is not null);
-
-		context.RegisterSourceOutput(provider, Execute);
-	}
+		=> GeneratorHelpers.RegisterClassGenerator(context, GeneratorAttributeName, Execute);
 
 	private void Execute(
 		SourceProductionContext context,

--- a/src/BB84.SourceGenerators/Helpers/GeneratorHelpers.cs
+++ b/src/BB84.SourceGenerators/Helpers/GeneratorHelpers.cs
@@ -158,6 +158,30 @@ internal static class GeneratorHelpers
 		=> context.TargetNode is not ClassDeclarationSyntax classSyntax ? null : ((ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)?)(classSyntax, context.SemanticModel);
 
 	/// <summary>
+	/// Registers a class-based incremental source generator pipeline that filters for classes
+	/// decorated with the specified attribute, transforms them via <see cref="TransformClassSyntax"/>,
+	/// and invokes the provided <paramref name="execute"/> callback.
+	/// </summary>
+	/// <param name="context">The generator initialization context.</param>
+	/// <param name="attributeMetadataName">The fully qualified metadata name of the trigger attribute.</param>
+	/// <param name="execute">The callback to execute for each matched class.</param>
+	internal static void RegisterClassGenerator(
+		IncrementalGeneratorInitializationContext context,
+		string attributeMetadataName,
+		Action<SourceProductionContext, (ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)?> execute)
+	{
+		IncrementalValuesProvider<(ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)?> provider =
+			context.SyntaxProvider
+				.ForAttributeWithMetadataName(
+					fullyQualifiedMetadataName: attributeMetadataName,
+					predicate: static (node, _) => node is ClassDeclarationSyntax,
+					transform: static (ctx, _) => TransformClassSyntax(ctx))
+				.Where(static result => result is not null);
+
+		context.RegisterSourceOutput(provider, execute);
+	}
+
+	/// <summary>
 	/// Attempts to create a <see cref="GeneratorContext"/> from the given input tuple.
 	/// Resolves the class symbol, extracts name, namespace, accessibility, and outer classes.
 	/// </summary>

--- a/src/BB84.SourceGenerators/IniFileGenerator.cs
+++ b/src/BB84.SourceGenerators/IniFileGenerator.cs
@@ -33,17 +33,7 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 
 	/// <inheritdoc/>
 	public void Initialize(IncrementalGeneratorInitializationContext context)
-	{
-		IncrementalValuesProvider<(ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)?> provider =
-			context.SyntaxProvider
-				.ForAttributeWithMetadataName(
-					fullyQualifiedMetadataName: GeneratorAttributeName,
-					predicate: static (node, _) => node is ClassDeclarationSyntax,
-					transform: static (ctx, _) => GeneratorHelpers.TransformClassSyntax(ctx))
-				.Where(static result => result is not null);
-
-		context.RegisterSourceOutput(provider, Execute);
-	}
+		=> GeneratorHelpers.RegisterClassGenerator(context, GeneratorAttributeName, Execute);
 
 	private void Execute(SourceProductionContext context, (ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)? input)
 	{

--- a/src/BB84.SourceGenerators/NotificationsGenerator.cs
+++ b/src/BB84.SourceGenerators/NotificationsGenerator.cs
@@ -4,7 +4,6 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 using BB84.SourceGenerators.Attributes;
-using BB84.SourceGenerators.Extensions;
 using BB84.SourceGenerators.Helpers;
 using BB84.SourceGenerators.Models;
 
@@ -28,17 +27,7 @@ public sealed class NotificationsGenerator : IIncrementalGenerator
 
 	/// <inheritdoc/>
 	public void Initialize(IncrementalGeneratorInitializationContext context)
-	{
-		IncrementalValuesProvider<(ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)?> provider =
-			context.SyntaxProvider
-				.ForAttributeWithMetadataName(
-					fullyQualifiedMetadataName: GeneratorAttributeName,
-					predicate: static (node, _) => node is ClassDeclarationSyntax,
-					transform: static (ctx, _) => GeneratorHelpers.TransformClassSyntax(ctx))
-				.Where(static result => result is not null);
-
-		context.RegisterSourceOutput(provider, Execute);
-	}
+		=> GeneratorHelpers.RegisterClassGenerator(context, GeneratorAttributeName, Execute);
 
 	private void Execute(SourceProductionContext context, (ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)? input)
 	{

--- a/src/BB84.SourceGenerators/SingletonGenerator.cs
+++ b/src/BB84.SourceGenerators/SingletonGenerator.cs
@@ -27,17 +27,7 @@ public sealed class SingletonGenerator : IIncrementalGenerator
 
 	/// <inheritdoc/>
 	public void Initialize(IncrementalGeneratorInitializationContext context)
-	{
-		IncrementalValuesProvider<(ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)?> provider =
-			context.SyntaxProvider
-				.ForAttributeWithMetadataName(
-					fullyQualifiedMetadataName: GeneratorAttributeName,
-					predicate: static (node, _) => node is ClassDeclarationSyntax,
-					transform: static (ctx, _) => GeneratorHelpers.TransformClassSyntax(ctx))
-				.Where(static result => result is not null);
-
-		context.RegisterSourceOutput(provider, Execute);
-	}
+		=> GeneratorHelpers.RegisterClassGenerator(context, GeneratorAttributeName, Execute);
 
 	private void Execute(SourceProductionContext context, (ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)? input)
 	{

--- a/src/BB84.SourceGenerators/ToStringGenerator.cs
+++ b/src/BB84.SourceGenerators/ToStringGenerator.cs
@@ -27,17 +27,7 @@ public sealed class ToStringGenerator : IIncrementalGenerator
 
 	/// <inheritdoc/>
 	public void Initialize(IncrementalGeneratorInitializationContext context)
-	{
-		IncrementalValuesProvider<(ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)?> provider =
-			context.SyntaxProvider
-				.ForAttributeWithMetadataName(
-					fullyQualifiedMetadataName: GeneratorAttributeName,
-					predicate: static (node, _) => node is ClassDeclarationSyntax,
-					transform: static (ctx, _) => GeneratorHelpers.TransformClassSyntax(ctx))
-				.Where(static result => result is not null);
-
-		context.RegisterSourceOutput(provider, Execute);
-	}
+		=> GeneratorHelpers.RegisterClassGenerator(context, GeneratorAttributeName, Execute);
 
 	private void Execute(SourceProductionContext context, (ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)? input)
 	{

--- a/src/BB84.SourceGenerators/ValidatorGenerator.cs
+++ b/src/BB84.SourceGenerators/ValidatorGenerator.cs
@@ -29,17 +29,7 @@ public sealed class ValidatorGenerator : IIncrementalGenerator
 
 	/// <inheritdoc/>
 	public void Initialize(IncrementalGeneratorInitializationContext context)
-	{
-		IncrementalValuesProvider<(ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)?> provider =
-			context.SyntaxProvider
-				.ForAttributeWithMetadataName(
-					fullyQualifiedMetadataName: GeneratorAttributeName,
-					predicate: static (node, _) => node is ClassDeclarationSyntax,
-					transform: static (ctx, _) => GeneratorHelpers.TransformClassSyntax(ctx))
-				.Where(static result => result is not null);
-
-		context.RegisterSourceOutput(provider, Execute);
-	}
+		=> GeneratorHelpers.RegisterClassGenerator(context, GeneratorAttributeName, Execute);
 
 	private void Execute(SourceProductionContext context, (ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)? input)
 	{


### PR DESCRIPTION
**Changes:**

- Centralize and deduplicate incremental generator registration by introducing `GeneratorHelpers.RegisterClassGenerator`.
- Refactor all class-based generators to use this helper, reducing boilerplate and improving maintainability.
- Also, adjust property accessor formatting in `AbstractionGenerator` for consistency and remove an unused using directive from `NotificationsGenerator`.

closes #92 