### PR TITLE
fix: Enforce stricter validation for [GenerateIniFileSection]

### DIFF
--- a/src/BB84.SourceGenerators/Analyzers/DiagnosticDescriptors.cs
+++ b/src/BB84.SourceGenerators/Analyzers/DiagnosticDescriptors.cs
@@ -129,4 +129,40 @@ internal static class DiagnosticDescriptors
 		category: "BB84.SourceGenerators",
 		defaultSeverity: DiagnosticSeverity.Error,
 		isEnabledByDefault: true);
+
+	/// <summary>
+	/// Represents a diagnostic error indicating that a property decorated with [GenerateIniFileSection]
+	/// has a nullable type, which is not supported.
+	/// </summary>
+	internal static readonly DiagnosticDescriptor IniFileSectionNullablePropertyDiagnostic = new(
+		id: "BB84SG0011",
+		title: "IniFile section property must not be nullable",
+		messageFormat: "The property '{0}' on class '{1}' decorated with [GenerateIniFileSection] must not be nullable",
+		category: "BB84.SourceGenerators",
+		defaultSeverity: DiagnosticSeverity.Error,
+		isEnabledByDefault: true);
+
+	/// <summary>
+	/// Represents a diagnostic error indicating that a property decorated with [GenerateIniFileSection]
+	/// is not initialized.
+	/// </summary>
+	internal static readonly DiagnosticDescriptor IniFileSectionUninitializedPropertyDiagnostic = new(
+		id: "BB84SG0012",
+		title: "IniFile section property must be initialized",
+		messageFormat: "The property '{0}' on class '{1}' decorated with [GenerateIniFileSection] must be initialized",
+		category: "BB84.SourceGenerators",
+		defaultSeverity: DiagnosticSeverity.Error,
+		isEnabledByDefault: true);
+
+	/// <summary>
+	/// Represents a diagnostic error indicating that a property decorated with [GenerateIniFileSection]
+	/// does not have a public getter.
+	/// </summary>
+	internal static readonly DiagnosticDescriptor IniFileSectionNoPublicGetterDiagnostic = new(
+		id: "BB84SG0013",
+		title: "IniFile section property must have a public getter",
+		messageFormat: "The property '{0}' on class '{1}' decorated with [GenerateIniFileSection] must have a public getter",
+		category: "BB84.SourceGenerators",
+		defaultSeverity: DiagnosticSeverity.Error,
+		isEnabledByDefault: true);
 }

--- a/src/BB84.SourceGenerators/IniFileGenerator.cs
+++ b/src/BB84.SourceGenerators/IniFileGenerator.cs
@@ -3,6 +3,7 @@
 //
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
+using BB84.SourceGenerators.Analyzers;
 using BB84.SourceGenerators.Attributes;
 using BB84.SourceGenerators.Extensions;
 using BB84.SourceGenerators.Helpers;
@@ -44,6 +45,9 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 		bool serializeComments = GetSerializeComments(ctx.ClassDeclaration);
 
 		List<SectionInfo> sections = GetSections(ctx.ClassDeclaration, ctx.SemanticModel, sectionDelimiter, serializeComments);
+
+		if (!ValidateSectionProperties(context, ctx.ClassDeclaration, ctx.SemanticModel))
+			return;
 
 		SourceBuilder sb = new();
 
@@ -127,33 +131,6 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 			sb.AppendLine($"{elsePrefix}if (string.Equals(currentSection, \"{section.SectionName}\", StringComparison.{stringComparison}))");
 			sb.OpenBrace();
 
-			if (section.NeedsInitialization)
-			{
-				sb.AppendLine($"if (result.{section.PropertyPath} == null)");
-				sb.Indent();
-				sb.AppendLine($"result.{section.PropertyPath} = new {section.TypeName}();");
-				sb.Outdent();
-				sb.AppendLine();
-			}
-			else if (section.PropertyPath.Contains("."))
-			{
-				// Ensure parent path segments are initialized for nested sections
-				string[] segments = section.PropertyPath.Split('.');
-				for (int i = 0; i < segments.Length - 1; i++)
-				{
-					string parentPath = string.Join(".", segments, 0, i + 1);
-					SectionInfo? parentSection = sections.FirstOrDefault(ps => ps.PropertyPath == parentPath);
-					if (parentSection is not null)
-					{
-						sb.AppendLine($"if (result.{parentPath} == null)");
-						sb.Indent();
-						sb.AppendLine($"result.{parentPath} = new {parentSection.TypeName}();");
-						sb.Outdent();
-						sb.AppendLine();
-					}
-				}
-			}
-
 			for (int v = 0; v < section.Values.Count; v++)
 			{
 				ValueInfo value = section.Values[v];
@@ -220,10 +197,6 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 			if (s > 0)
 				sb.AppendLine("sb.AppendLine();");
 
-			string nullCheck = BuildNullCheck($"instance.{section.PropertyPath}");
-			sb.AppendLine($"if ({nullCheck})");
-			sb.OpenBrace();
-
 			if (serializeComments && section.Comment is not null)
 				sb.AppendLine($"sb.AppendLine(\"; {GeneratorHelpers.EscapeString(section.Comment)}\");");
 
@@ -236,8 +209,6 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 
 				sb.AppendLine($"sb.AppendLine(\"{value.KeyName}=\" + {GetToStringExpression($"instance.{section.PropertyPath}.{value.PropertyName}", value)});");
 			}
-
-			sb.CloseBrace();
 		}
 
 		sb.AppendLine();
@@ -318,15 +289,8 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 
 		foreach (SectionInfo section in sections)
 		{
-			string targetNullCheck = BuildNullCheck($"this.{section.PropertyPath}");
-			string sourceNullCheck = BuildNullCheck($"other.{section.PropertyPath}");
-			sb.AppendLine($"if ({targetNullCheck} && {sourceNullCheck})");
-			sb.OpenBrace();
-
 			foreach (ValueInfo value in section.Values)
 				sb.AppendLine($"{section.PropertyPath}.{value.PropertyName} = other.{section.PropertyPath}.{value.PropertyName};");
-
-			sb.CloseBrace();
 		}
 
 		sb.CloseBrace();
@@ -354,7 +318,6 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 				continue;
 
 			string sectionName = GetExplicitNameOrDefault(sectionAttribute, propertySymbol.Name);
-			bool needsInit = !HasInitializer(classDeclaration, propertySymbol.Name);
 			string propertyPath = propertySymbol.Name;
 			string? comment = serializeComments ? GetXmlSummaryComment(propertySymbol) : null;
 
@@ -366,7 +329,6 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 				PropertyPath: propertyPath,
 				SectionName: sectionName,
 				TypeName: sectionTypeName,
-				NeedsInitialization: needsInit,
 				Values: values,
 				Comment: comment
 			));
@@ -408,10 +370,9 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 				PropertyPath: propertyPath,
 				SectionName: fullSectionName,
 				TypeName: sectionTypeName,
-				NeedsInitialization: false,
 				Values: values,
 				Comment: comment
-			));
+				));
 
 			CollectNestedSections(sections, sectionType, fullSectionName, propertyPath, sectionDelimiter, depth + 1, serializeComments);
 		}
@@ -488,12 +449,19 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 	{
 		foreach (MemberDeclarationSyntax member in classDeclaration.Members)
 		{
-			if (member is PropertyDeclarationSyntax propSyntax
-				&& propSyntax.Identifier.Text == propertyName
-				&& propSyntax.Initializer is not null)
-			{
+			if (member is PropertyDeclarationSyntax propSyntax && propSyntax.Identifier.Text == propertyName && propSyntax.Initializer is not null)
 				return true;
-			}
+		}
+
+		return false;
+	}
+
+	private static bool HasInitializer(INamedTypeSymbol typeSymbol, string propertyName)
+	{
+		foreach (SyntaxReference syntaxRef in typeSymbol.DeclaringSyntaxReferences)
+		{
+			if (syntaxRef.GetSyntax() is ClassDeclarationSyntax classDeclaration && HasInitializer(classDeclaration, propertyName))
+				return true;
 		}
 
 		return false;
@@ -575,7 +543,7 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 			string emptyFallback = value.IsArray
 				? $"Array.Empty<{value.CollectionElementTypeName}>()"
 				: $"Enumerable.Empty<{value.CollectionElementTypeName}>()";
-			
+
 			return $"string.Join(\",\", ({expression} ?? {emptyFallback}).Select(e => {elementToString}))";
 		}
 
@@ -711,19 +679,74 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 		return null;
 	}
 
-	private static string BuildNullCheck(string propertyPath)
+	private static bool ValidateSectionProperties(SourceProductionContext context, ClassDeclarationSyntax classDeclaration, SemanticModel semanticModel)
 	{
-		string[] segments = propertyPath.Split('.');
-		if (segments.Length <= 2)
-			return $"{propertyPath} != null";
+		INamedTypeSymbol? classSymbol = semanticModel.GetDeclaredSymbol(classDeclaration);
 
-		List<string> checks = [];
-		for (int i = 1; i < segments.Length; i++)
+		if (classSymbol is null)
+			return false;
+
+		bool isValid = true;
+		ValidateSectionPropertiesOnType(context, classSymbol, classDeclaration, ref isValid);
+		return isValid;
+	}
+
+	private static void ValidateSectionPropertiesOnType(SourceProductionContext context, INamedTypeSymbol typeSymbol, ClassDeclarationSyntax? classDeclaration, ref bool isValid)
+	{
+		foreach (ISymbol member in typeSymbol.GetMembers())
 		{
-			checks.Add($"{string.Join(".", segments, 0, i + 1)} != null");
-		}
+			if (member is not IPropertySymbol propertySymbol)
+				continue;
 
-		return string.Join(" && ", checks);
+			AttributeData? sectionAttribute = FindAttribute(propertySymbol, SectionAttributeName);
+
+			if (sectionAttribute is null)
+				continue;
+
+			string className = typeSymbol.Name;
+			Location location = propertySymbol.Locations.FirstOrDefault() ?? Location.None;
+
+			// Check nullable
+			if (propertySymbol.Type.NullableAnnotation == NullableAnnotation.Annotated)
+			{
+				context.ReportDiagnostic(Diagnostic.Create(
+					DiagnosticDescriptors.IniFileSectionNullablePropertyDiagnostic,
+					location,
+					propertySymbol.Name,
+					className));
+				isValid = false;
+			}
+
+			// Check initialized
+			bool hasInit = classDeclaration is not null
+				? HasInitializer(classDeclaration, propertySymbol.Name)
+				: HasInitializer(typeSymbol, propertySymbol.Name);
+
+			if (!hasInit)
+			{
+				context.ReportDiagnostic(Diagnostic.Create(
+					DiagnosticDescriptors.IniFileSectionUninitializedPropertyDiagnostic,
+					location,
+					propertySymbol.Name,
+					className));
+				isValid = false;
+			}
+
+			// Check public getter
+			if (propertySymbol.GetMethod is null || propertySymbol.GetMethod.DeclaredAccessibility != Accessibility.Public)
+			{
+				context.ReportDiagnostic(Diagnostic.Create(
+					DiagnosticDescriptors.IniFileSectionNoPublicGetterDiagnostic,
+					location,
+					propertySymbol.Name,
+					className));
+				isValid = false;
+			}
+
+			// Recursively validate nested section types
+			if (propertySymbol.Type is INamedTypeSymbol nestedType)
+				ValidateSectionPropertiesOnType(context, nestedType, null, ref isValid);
+		}
 	}
 
 	private static AttributeData? FindAttribute(IPropertySymbol propertySymbol, string attributeName)
@@ -774,7 +797,6 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 		string PropertyPath,
 		string SectionName,
 		string TypeName,
-		bool NeedsInitialization,
 		List<ValueInfo> Values,
 		string? Comment = null
 	);

--- a/tests/BB84.SourceGenerators.Tests/EdgeCaseTests.cs
+++ b/tests/BB84.SourceGenerators.Tests/EdgeCaseTests.cs
@@ -253,8 +253,8 @@ public sealed class EdgeCaseTests
 		TestIniFile result = TestIniFile.Read(content);
 
 		Assert.IsNotNull(result);
-		Assert.IsNull(result.General);
-		Assert.IsNull(result.Database);
+		Assert.IsNotNull(result.General);
+		Assert.IsNotNull(result.Database);
 	}
 
 	[TestMethod]

--- a/tests/BB84.SourceGenerators.Tests/GeneratorDriverTests.cs
+++ b/tests/BB84.SourceGenerators.Tests/GeneratorDriverTests.cs
@@ -1253,6 +1253,116 @@ namespace TestNamespace
 		Assert.IsEmpty(autoMapperErrors, string.Join("\n", autoMapperErrors.Select(e => e.ToString())));
 	}
 
+	[TestMethod]
+	public void IniFileGeneratorShouldReportDiagnosticForNullableSectionProperty()
+	{
+		string source = @"
+#nullable enable
+using BB84.SourceGenerators.Attributes;
+
+namespace TestNamespace
+{
+	public class MySection
+	{
+		[GenerateIniFileValue]
+		public string? Name { get; set; }
+	}
+
+	[GenerateIniFile]
+	internal sealed partial class MyConfig
+	{
+		[GenerateIniFileSection]
+		public MySection? Section { get; set; } = new();
+	}
+}";
+
+		(ImmutableArray<Diagnostic> diagnostics, string[] generatedSources) = RunGenerator<IniFileGenerator>(source);
+
+		Assert.IsNotEmpty(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error && d.Id == "BB84SG0011"));
+	}
+
+	[TestMethod]
+	public void IniFileGeneratorShouldReportDiagnosticForUninitializedSectionProperty()
+	{
+		string source = @"
+using BB84.SourceGenerators.Attributes;
+
+namespace TestNamespace
+{
+	public class MySection
+	{
+		[GenerateIniFileValue]
+		public string Name { get; set; }
+	}
+
+	[GenerateIniFile]
+	internal sealed partial class MyConfig
+	{
+		[GenerateIniFileSection]
+		public MySection Section { get; set; }
+	}
+}";
+
+		(ImmutableArray<Diagnostic> diagnostics, string[] generatedSources) = RunGenerator<IniFileGenerator>(source);
+
+		Assert.IsNotEmpty(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error && d.Id == "BB84SG0012"));
+	}
+
+	[TestMethod]
+	public void IniFileGeneratorShouldReportDiagnosticForNoPublicGetter()
+	{
+		string source = @"
+using BB84.SourceGenerators.Attributes;
+
+namespace TestNamespace
+{
+	public class MySection
+	{
+		[GenerateIniFileValue]
+		public string Name { get; set; }
+	}
+
+	[GenerateIniFile]
+	internal sealed partial class MyConfig
+	{
+		[GenerateIniFileSection]
+		public MySection Section { private get; set; } = new();
+	}
+}";
+
+		(ImmutableArray<Diagnostic> diagnostics, string[] generatedSources) = RunGenerator<IniFileGenerator>(source);
+
+		Assert.IsNotEmpty(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error && d.Id == "BB84SG0013"));
+	}
+
+	[TestMethod]
+	public void IniFileGeneratorShouldNotReportDiagnosticForValidSectionProperty()
+	{
+		string source = @"
+using BB84.SourceGenerators.Attributes;
+
+namespace TestNamespace
+{
+	public class MySection
+	{
+		[GenerateIniFileValue]
+		public string Name { get; set; }
+	}
+
+	[GenerateIniFile]
+	internal sealed partial class MyConfig
+	{
+		[GenerateIniFileSection]
+		public MySection Section { get; set; } = new();
+	}
+}";
+
+		(ImmutableArray<Diagnostic> diagnostics, string[] generatedSources) = RunGenerator<IniFileGenerator>(source);
+
+		Assert.IsEmpty(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
+		Assert.IsNotEmpty(generatedSources);
+	}
+
 	private static (ImmutableArray<Diagnostic> Diagnostics, string[] GeneratedSources) RunGenerator<TGenerator>(string source)
 		where TGenerator : IIncrementalGenerator, new()
 	{

--- a/tests/BB84.SourceGenerators.Tests/IniFileGeneratorTests.cs
+++ b/tests/BB84.SourceGenerators.Tests/IniFileGeneratorTests.cs
@@ -329,8 +329,8 @@ public sealed class IniFileGeneratorTests
 		TestIniFile result = TestIniFile.Read(content);
 
 		Assert.IsNotNull(result);
-		Assert.IsNull(result.General);
-		Assert.IsNull(result.Database);
+		Assert.IsNotNull(result.General);
+		Assert.IsNotNull(result.Database);
 	}
 
 	[TestMethod]
@@ -417,7 +417,10 @@ public sealed class IniFileGeneratorTests
 
 		TestIniFileCaseSensitive result = TestIniFileCaseSensitive.Read(content);
 
-		Assert.IsNull(result.General);
+		Assert.IsNotNull(result.General);
+		Assert.IsNull(result.General.AppName);
+		Assert.AreEqual(0, result.General.Version);
+		Assert.IsFalse(result.General.Enabled);
 	}
 
 	[TestMethod]
@@ -690,21 +693,6 @@ public sealed class IniFileGeneratorTests
 
 		Assert.AreEqual("new-domain", target.Section.Domain);
 		Assert.AreEqual("new-foo", target.Section.SubSection.Foo);
-	}
-
-	[TestMethod]
-	public void LoadShouldNotThrowWhenNestedParentIsNull()
-	{
-		TestIniFileWithNestedSection target = new();
-		TestIniFileWithNestedSection source = new() { Section = new() { SubSection = new() } };
-
-		target.Section = null!;
-		source.Section.Domain = "new-domain";
-		source.Section.SubSection.Foo = "new-foo";
-
-		target.Load(source);
-
-		Assert.IsNull(target.Section);
 	}
 
 	[TestMethod]

--- a/tests/BB84.SourceGenerators.Tests/IniFileGeneratorTests.cs
+++ b/tests/BB84.SourceGenerators.Tests/IniFileGeneratorTests.cs
@@ -230,26 +230,6 @@ public sealed class IniFileGeneratorTests
 	}
 
 	[TestMethod]
-	public void WriteShouldSkipNullSections()
-	{
-		TestIniFile instance = new()
-		{
-			General = new TestGeneralSection
-			{
-				AppName = "TestApp",
-				Version = 1,
-				Enabled = true
-			},
-			Database = null
-		};
-
-		string result = TestIniFile.Write(instance);
-
-		Assert.Contains("[General]", result);
-		Assert.DoesNotContain("[Database]", result);
-	}
-
-	[TestMethod]
 	public void ReadThenWriteShouldRoundTrip()
 	{
 		TestIniFile original = new()
@@ -696,38 +676,13 @@ public sealed class IniFileGeneratorTests
 	}
 
 	[TestMethod]
-	public void LoadShouldSkipNullSections()
-	{
-		TestIniFile target = new()
-		{
-			General = new TestGeneralSection { AppName = "Keep", Version = 1, Enabled = true },
-			Database = null
-		};
-
-		TestIniFile source = new()
-		{
-			General = new TestGeneralSection { AppName = "New", Version = 5, Enabled = false },
-			Database = new TestDatabaseSection { Host = "host", Port = 9999, Timeout = 99.0 }
-		};
-
-		target.Load(source);
-
-		// General should be updated
-		Assert.AreEqual("New", target.General.AppName);
-		Assert.AreEqual(5, target.General.Version);
-
-		// Database should remain null (target section is null)
-		Assert.IsNull(target.Database);
-	}
-
-	[TestMethod]
 	public void LoadShouldCopyNestedSectionValues()
 	{
-		TestIniFileWithNestedSection target = new() { Section = new() };
+		TestIniFileWithNestedSection target = new() { Section = new() { SubSection = new() } };
 		target.Section.Domain = "old-domain";
 		target.Section.SubSection.Foo = "old-foo";
 
-		TestIniFileWithNestedSection source = new() { Section = new() };
+		TestIniFileWithNestedSection source = new() { Section = new() { SubSection = new() } };
 		source.Section.Domain = "new-domain";
 		source.Section.SubSection.Foo = "new-foo";
 
@@ -741,7 +696,7 @@ public sealed class IniFileGeneratorTests
 	public void LoadShouldNotThrowWhenNestedParentIsNull()
 	{
 		TestIniFileWithNestedSection target = new();
-		TestIniFileWithNestedSection source = new() { Section = new() };
+		TestIniFileWithNestedSection source = new() { Section = new() { SubSection = new() } };
 
 		target.Section = null!;
 		source.Section.Domain = "new-domain";
@@ -978,10 +933,10 @@ public sealed class IniFileGeneratorTests
 internal sealed partial class TestIniFile
 {
 	[GenerateIniFileSection]
-	public TestGeneralSection? General { get; set; }
+	public TestGeneralSection General { get; set; } = new();
 
 	[GenerateIniFileSection]
-	public TestDatabaseSection? Database { get; set; }
+	public TestDatabaseSection Database { get; set; } = new();
 }
 
 public class TestGeneralSection
@@ -1012,10 +967,10 @@ public class TestDatabaseSection
 internal sealed partial class TestIniFileWithCustomNames
 {
 	[GenerateIniFileSection("CustomSection")]
-	public TestCustomSection? Stats { get; set; }
+	public TestCustomSection Stats { get; set; } = new();
 
 	[GenerateIniFileSection]
-	public TestMetricsSection? Metrics { get; set; }
+	public TestMetricsSection Metrics { get; set; } = new();
 }
 
 public class TestCustomSection
@@ -1034,7 +989,7 @@ public class TestMetricsSection
 internal sealed partial class TestIniFileAllTypes
 {
 	[GenerateIniFileSection]
-	public TestAllTypesSection? AllTypes { get; set; }
+	public TestAllTypesSection AllTypes { get; set; } = new();
 }
 
 public class TestAllTypesSection
@@ -1081,22 +1036,26 @@ public class TestSettingsSection
 internal sealed partial class TestIniFileCaseSensitive
 {
 	[GenerateIniFileSection]
-	public TestGeneralSection? General { get; set; }
+	public TestGeneralSection General { get; set; } = new();
 }
 
 [GenerateIniFile]
 internal sealed partial class TestIniFileWithNestedSection
 {
 	[GenerateIniFileSection]
-	public TestSection? Section { get; set; }
+	public TestSection Section { get; set; } = new();
 }
 
 public class TestSection
 {
 	[GenerateIniFileValue]
 	public string? Domain { get; set; }
+
 	[GenerateIniFileSection]
-	public TestSubSection SubSection { get; set; } = new TestSubSection();
+	public TestSubSection SubSection { get; set; } = new();
+
+	[GenerateIniFileSection]
+	public TestSubSection OtherSubSection { get; set; } = new();
 }
 
 public class TestSubSection
@@ -1121,7 +1080,7 @@ public enum TestPermissions { None = 0, Read = 1, Write = 2, Execute = 4 }
 internal sealed partial class TestIniFileWithEnums
 {
 	[GenerateIniFileSection]
-	public TestAppSection? App { get; set; }
+	public TestAppSection App { get; set; } = new();
 }
 
 public class TestAppSection
@@ -1134,7 +1093,7 @@ public class TestAppSection
 internal sealed partial class TestIniFileWithFlagsEnum
 {
 	[GenerateIniFileSection]
-	public TestFlagsAppSection? App { get; set; }
+	public TestFlagsAppSection App { get; set; } = new();
 }
 
 public class TestFlagsAppSection
@@ -1150,7 +1109,7 @@ internal sealed partial class TestIniFileWithComments
 	/// General application settings
 	/// </summary>
 	[GenerateIniFileSection]
-	public TestCommentedGeneralSection? General { get; set; }
+	public TestCommentedGeneralSection General { get; set; } = new();
 }
 
 public class TestCommentedGeneralSection
@@ -1172,7 +1131,7 @@ public class TestCommentedGeneralSection
 internal sealed partial class TestIniFileExtendedTypes
 {
 	[GenerateIniFileSection]
-	public TestExtendedTypesSection? Extended { get; set; }
+	public TestExtendedTypesSection Extended { get; set; } = new();
 }
 
 public class TestExtendedTypesSection
@@ -1191,7 +1150,7 @@ public class TestExtendedTypesSection
 internal sealed partial class TestIniFileCollections
 {
 	[GenerateIniFileSection]
-	public TestCollectionsSection? Collections { get; set; }
+	public TestCollectionsSection Collections { get; set; } = new();
 }
 
 public class TestCollectionsSection
@@ -1207,7 +1166,7 @@ public class TestCollectionsSection
 internal sealed partial class TestIniFileArrays
 {
 	[GenerateIniFileSection]
-	public TestArraysSection? Arrays { get; set; }
+	public TestArraysSection Arrays { get; set; } = new();
 }
 
 public class TestArraysSection


### PR DESCRIPTION
**Changes:**

- Added 3 diagnostic descriptors (`BB84SG0011`, `BB84SG0012`, `BB84SG0013`) for nullable, uninitialized, and missing public getter section properties.
- Added `ValidateSectionProperties` and `ValidateSectionPropertiesOnType` methods that recursively validate all section-decorated properties.
- Removed `NeedsInitialization` from `SectionInfo` and all related null-check/initialization logic from the generated `Read`, `Write`, and `Load` methods.
- Removed `BuildNullCheck` helper since it's no longer needed.
- Updated test models to conform to the new requirements (non-nullable, initialized, public getter).
- Added new tests in `GeneratorDriverTests.cs` to verify that the `IniFileGenerator` reports diagnostics for nullable, uninitialized, and non-public section properties, and does not report errors for valid properties.
- Updated `IniFileGeneratorTests.cs` to modify assertions in `ReadShouldHandleEmptyContent` and `ReadShouldNotMatchWhenCaseSensitiveAndCaseDiffers` to ensure proper handling of default values.
- Removed the `LoadShouldNotThrowWhenNestedParentIsNull` test as it is no longer relevant.
