### PR TITLE
Add multi-framework support and conditional logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,11 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
 
+      - name: Install mono
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mono-complete
+
       - name: Restore dependencies
         run: dotnet restore BB84.SourceGenerators.slnx
 
@@ -28,7 +33,7 @@ jobs:
         run: dotnet build BB84.SourceGenerators.slnx --configuration Release --no-restore
 
       - name: Run tests
-        run: dotnet test BB84.SourceGenerators.slnx --configuration Release --no-build --verbosity normal --logger "trx;LogFileName=test-results.trx"
+        run: dotnet test BB84.SourceGenerators.slnx --configuration Release --no-build --verbosity normal --logger "trx;LogFileName=test-results-{framework}.trx"
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         run: dotnet build BB84.SourceGenerators.slnx --configuration Release --no-restore
 
       - name: Run tests
-        run: dotnet test BB84.SourceGenerators.slnx --configuration Release --no-build --verbosity normal --logger "trx;LogFileName=test-results-{framework}.trx"
+        run: dotnet test BB84.SourceGenerators.slnx --configuration Release --no-build --verbosity normal --logger trx
 
       - name: Upload test results
         if: always()

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <ManagePackageVersionsCentrally>True</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
     <!--Version 4.14 includes C# 13.0 (Visual Studio 2022 version 17.14, .NET 9)-->
@@ -9,5 +9,6 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="[4.14, 5.0.0)" />
     <PackageVersion Include="MSTest" Version="4.2.3" />
     <PackageVersion Include="PolySharp" Version="1.15.0" />
+		<PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 </Project>

--- a/src/BB84.SourceGenerators/IniFileGenerator.cs
+++ b/src/BB84.SourceGenerators/IniFileGenerator.cs
@@ -226,9 +226,17 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 		sb.AppendLine("/// <param name=\"reader\">The <see cref=\"TextReader\"/> to read from.</param>");
 		sb.AppendLine("/// <param name=\"cancellationToken\">A cancellation token that can be used to cancel the asynchronous operation.</param>");
 		sb.AppendLine($"/// <returns>A task representing the asynchronous operation, containing the deserialized <see cref=\"{className}\"/> instance.</returns>");
+		sb.AppendLine("#if NET5_0_OR_GREATER");
 		sb.AppendLine($"public static async Task<{className}> ReadAsync(TextReader reader, CancellationToken cancellationToken = default)");
+		sb.AppendLine("#else");
+		sb.AppendLine($"public static async Task<{className}> ReadAsync(TextReader reader)");
+		sb.AppendLine("#endif");
 		sb.OpenBrace();
+		sb.AppendLine("#if NET5_0_OR_GREATER");
 		sb.AppendLine("string content = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);");
+		sb.AppendLine("#else");
+		sb.AppendLine("string content = await reader.ReadToEndAsync().ConfigureAwait(false);");
+		sb.AppendLine("#endif");
 		sb.AppendLine("return Read(content);");
 		sb.CloseBrace();
 		sb.AppendLine();
@@ -239,10 +247,18 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 		sb.AppendLine("/// <param name=\"stream\">The <see cref=\"Stream\"/> to read from.</param>");
 		sb.AppendLine("/// <param name=\"cancellationToken\">A cancellation token that can be used to cancel the asynchronous operation.</param>");
 		sb.AppendLine($"/// <returns>A task representing the asynchronous operation, containing the deserialized <see cref=\"{className}\"/> instance.</returns>");
+		sb.AppendLine("#if NET5_0_OR_GREATER");
 		sb.AppendLine($"public static async Task<{className}> ReadAsync(Stream stream, CancellationToken cancellationToken = default)");
+		sb.AppendLine("#else");
+		sb.AppendLine($"public static async Task<{className}> ReadAsync(Stream stream)");
+		sb.AppendLine("#endif");
 		sb.OpenBrace();
 		sb.AppendLine("using StreamReader reader = new StreamReader(stream, Encoding.UTF8, true, 1024, leaveOpen: true);");
+		sb.AppendLine("#if NET5_0_OR_GREATER");
 		sb.AppendLine("return await ReadAsync(reader, cancellationToken).ConfigureAwait(false);");
+		sb.AppendLine("#else");
+		sb.AppendLine("return await ReadAsync(reader).ConfigureAwait(false);");
+		sb.AppendLine("#endif");
 		sb.CloseBrace();
 	}
 
@@ -256,11 +272,19 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 		sb.AppendLine("/// <param name=\"writer\">The <see cref=\"TextWriter\"/> to write to.</param>");
 		sb.AppendLine("/// <param name=\"cancellationToken\">A cancellation token that can be used to cancel the asynchronous operation.</param>");
 		sb.AppendLine("/// <returns>A task representing the asynchronous operation.</returns>");
+		sb.AppendLine("#if NET5_0_OR_GREATER");
 		sb.AppendLine($"public static async Task WriteAsync({className} instance, TextWriter writer, CancellationToken cancellationToken = default)");
+		sb.AppendLine("#else");
+		sb.AppendLine($"public static async Task WriteAsync({className} instance, TextWriter writer)");
+		sb.AppendLine("#endif");
 		sb.OpenBrace();
 		sb.AppendLine("string content = Write(instance);");
+		sb.AppendLine("#if NET5_0_OR_GREATER");
 		sb.AppendLine("StringBuilder builder = new StringBuilder(content);");
 		sb.AppendLine("await writer.WriteAsync(builder, cancellationToken).ConfigureAwait(false);");
+		sb.AppendLine("#else");
+		sb.AppendLine("await writer.WriteAsync(content).ConfigureAwait(false);");
+		sb.AppendLine("#endif");
 		sb.CloseBrace();
 		sb.AppendLine();
 		sb.AppendLine("/// <summary>");
@@ -270,10 +294,18 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 		sb.AppendLine("/// <param name=\"stream\">The <see cref=\"Stream\"/> to write to.</param>");
 		sb.AppendLine("/// <param name=\"cancellationToken\">A cancellation token that can be used to cancel the asynchronous operation.</param>");
 		sb.AppendLine("/// <returns>A task representing the asynchronous operation.</returns>");
+		sb.AppendLine("#if NET5_0_OR_GREATER");
 		sb.AppendLine($"public static async Task WriteAsync({className} instance, Stream stream, CancellationToken cancellationToken = default)");
+		sb.AppendLine("#else");
+		sb.AppendLine($"public static async Task WriteAsync({className} instance, Stream stream)");
+		sb.AppendLine("#endif");
 		sb.OpenBrace();
 		sb.AppendLine("using StreamWriter writer = new StreamWriter(stream, Encoding.UTF8, 1024, leaveOpen: true);");
+		sb.AppendLine("#if NET5_0_OR_GREATER");
 		sb.AppendLine("await WriteAsync(instance, writer, cancellationToken).ConfigureAwait(false);");
+		sb.AppendLine("#else");
+		sb.AppendLine("await WriteAsync(instance, writer).ConfigureAwait(false);");
+		sb.AppendLine("#endif");
 		sb.CloseBrace();
 	}
 

--- a/tests/BB84.SourceGenerators.Tests/AbstractionGeneratorTests.cs
+++ b/tests/BB84.SourceGenerators.Tests/AbstractionGeneratorTests.cs
@@ -76,7 +76,13 @@ internal sealed partial class EnvironmentProvider
 public partial interface IEnvironmentProvider
 { }
 
-[GenerateAbstraction(typeof(Path), typeof(IPathProvider), typeof(PathProvider), ExcludeProperties = new string[] { nameof(Path.EndsInDirectorySeparator) })]
+[GenerateAbstraction(typeof(Path), typeof(IPathProvider), typeof(PathProvider), ExcludeProperties = new string[] {
+#if NET5_0_OR_GREATER
+	nameof(Path.EndsInDirectorySeparator)
+#else	
+	"EndsInDirectorySeparator"
+#endif
+})]
 internal sealed partial class PathProvider
 { }
 

--- a/tests/BB84.SourceGenerators.Tests/BB84.SourceGenerators.Tests.csproj
+++ b/tests/BB84.SourceGenerators.Tests/BB84.SourceGenerators.Tests.csproj
@@ -1,15 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<AppendTargetFrameworkToOutputPath>True</AppendTargetFrameworkToOutputPath>
-		<EmitCompilerGeneratedFiles>True</EmitCompilerGeneratedFiles>
 		<IsPackable>False</IsPackable>
 		<IsTestProject>True</IsTestProject>
 		<NoWarn>$(NoWarn);CA1859;CS1591;CA1711;CA1816</NoWarn>
-		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+		<TargetFrameworks>net472;net48;net8.0;net10.0</TargetFrameworks>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
 		<PackageReference Include="MSTest" />
+	</ItemGroup>
+	<ItemGroup Condition="$(TargetFrameworkIdentifier) == '.NETFramework'">
+		<PackageReference Include="PolySharp" />
+		<PackageReference Include="System.ComponentModel.Annotations" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\..\src\BB84.SourceGenerators\BB84.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="True" />

--- a/tests/BB84.SourceGenerators.Tests/IniFileGeneratorTests.cs
+++ b/tests/BB84.SourceGenerators.Tests/IniFileGeneratorTests.cs
@@ -853,9 +853,15 @@ public sealed class IniFileGeneratorTests
 		string content = "[General]\r\nAppName=AsyncApp\r\nVersion=7\r\nEnabled=True\r\n";
 		using StringReader reader = new(content);
 
+#if NET5_0_OR_GREATER
 		TestIniFile result = await TestIniFile
 			.ReadAsync(reader, _testToken)
 			.ConfigureAwait(false);
+#else
+		TestIniFile result = await TestIniFile
+			.ReadAsync(reader)
+			.ConfigureAwait(false);
+#endif
 
 		Assert.IsNotNull(result.General);
 		Assert.AreEqual("AsyncApp", result.General.AppName);
@@ -868,9 +874,15 @@ public sealed class IniFileGeneratorTests
 		string content = "[General]\r\nAppName=StreamApp\r\nVersion=3\r\nEnabled=False\r\n";
 		using MemoryStream stream = new(Encoding.UTF8.GetBytes(content));
 
+#if NET5_0_OR_GREATER
 		TestIniFile result = await TestIniFile
 			.ReadAsync(stream, _testToken)
 			.ConfigureAwait(false);
+#else
+		TestIniFile result = await TestIniFile
+			.ReadAsync(stream)
+			.ConfigureAwait(false);
+#endif
 
 		Assert.IsNotNull(result.General);
 		Assert.AreEqual("StreamApp", result.General.AppName);
@@ -886,9 +898,15 @@ public sealed class IniFileGeneratorTests
 		};
 		using StringWriter writer = new();
 
+#if NET5_0_OR_GREATER
 		await TestIniFile
 			.WriteAsync(instance, writer, _testToken)
 			.ConfigureAwait(false);
+#else
+		await TestIniFile
+			.WriteAsync(instance, writer)
+			.ConfigureAwait(false);
+#endif
 		string result = writer.ToString();
 
 		Assert.Contains("[General]", result);
@@ -904,9 +922,15 @@ public sealed class IniFileGeneratorTests
 		};
 		using MemoryStream stream = new();
 
+#if NET5_0_OR_GREATER
 		await TestIniFile
 			.WriteAsync(instance, stream, _testToken)
 			.ConfigureAwait(false);
+#else
+		await TestIniFile
+			.WriteAsync(instance, stream)
+			.ConfigureAwait(false);
+#endif
 		stream.Position = 0;
 		string result = new StreamReader(stream).ReadToEnd();
 


### PR DESCRIPTION
**Changes:**

- Capitalized `ManagePackageVersionsCentrally` for consistency.
- Added `System.ComponentModel.Annotations` package reference.
- Introduced `#if NET5_0_OR_GREATER` for framework-specific logic.
- Adjusted `ReadAsync` and `WriteAsync` methods for compatibility.
- Updated `GenerateAbstraction` attribute for `PathProvider`.
- Added `net472` and `net48` target frameworks in test project.
- Modified tests to validate framework-specific behavior.

closes #120 