### PR TITLE
refactor: attribute name handling in source generators

### DIFF
--- a/src/BB84.SourceGenerators/DisposableGenerator.cs
+++ b/src/BB84.SourceGenerators/DisposableGenerator.cs
@@ -23,15 +23,14 @@ namespace BB84.SourceGenerators;
 [Generator(LanguageNames.CSharp)]
 public sealed class DisposableGenerator : IIncrementalGenerator
 {
-	private static readonly string GeneratorAttributeName = typeof(GenerateDisposableAttribute).FullName;
-	private const string AttributeFullName = nameof(GenerateDisposableAttribute);
-	private static readonly string AttributeShortName = GeneratorHelpers.StripAttributeSuffix(AttributeFullName);
-	private const string DisposeResourceFullName = nameof(DisposeResourceAttribute);
-	private static readonly string DisposeResourceShortName = GeneratorHelpers.StripAttributeSuffix(DisposeResourceFullName);
+	private static readonly (string MetadataName, string FullName, string ShortName) AttributeNames =
+		GeneratorHelpers.GetAttributeNames<GenerateDisposableAttribute>();
+	private static readonly (string MetadataName, string FullName, string ShortName) DisposeResourceAttributeNames =
+		GeneratorHelpers.GetAttributeNames<DisposeResourceAttribute>();
 
 	/// <inheritdoc/>
 	public void Initialize(IncrementalGeneratorInitializationContext context)
-		=> GeneratorHelpers.RegisterClassGenerator(context, GeneratorAttributeName, Execute);
+		=> GeneratorHelpers.RegisterClassGenerator(context, AttributeNames.MetadataName, Execute);
 
 	private void Execute(SourceProductionContext context, (ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)? input)
 	{
@@ -109,7 +108,7 @@ public sealed class DisposableGenerator : IIncrementalGenerator
 			{
 				string name = attribute.Name.ToString();
 
-				if (name != AttributeShortName && name != AttributeFullName)
+				if (name != AttributeNames.ShortName && name != AttributeNames.FullName)
 					continue;
 
 				if (attribute.ArgumentList is null || attribute.ArgumentList.Arguments.Count == 0)
@@ -195,7 +194,7 @@ public sealed class DisposableGenerator : IIncrementalGenerator
 			{
 				string name = attribute.Name.ToString();
 
-				if (name != DisposeResourceShortName && name != DisposeResourceFullName)
+				if (name != DisposeResourceAttributeNames.ShortName && name != DisposeResourceAttributeNames.FullName)
 					continue;
 
 				if (attribute.ArgumentList is null || attribute.ArgumentList.Arguments.Count == 0)

--- a/src/BB84.SourceGenerators/Helpers/GeneratorHelpers.cs
+++ b/src/BB84.SourceGenerators/Helpers/GeneratorHelpers.cs
@@ -147,6 +147,23 @@ internal static class GeneratorHelpers
 			: attributeName;
 
 	/// <summary>
+	/// Returns the fully-qualified metadata name, the simple full name, and the short name
+	/// (without the "Attribute" suffix) for the given attribute type.
+	/// </summary>
+	/// <typeparam name="TAttribute">The attribute type.</typeparam>
+	/// <returns>
+	/// A tuple of <c>(MetadataName, FullName, ShortName)</c> where <c>MetadataName</c> is the
+	/// value of <see cref="Type.FullName"/>, <c>FullName</c> is the simple type name including
+	/// the "Attribute" suffix, and <c>ShortName</c> is the type name without the suffix.
+	/// </returns>
+	internal static (string MetadataName, string FullName, string ShortName) GetAttributeNames<TAttribute>()
+		where TAttribute : Attribute
+	{
+		string fullName = typeof(TAttribute).Name;
+		return (typeof(TAttribute).FullName, fullName, StripAttributeSuffix(fullName));
+	}
+
+	/// <summary>
 	/// Escapes a string for use in a regular string literal.
 	/// </summary>
 	/// <param name="value">The string value to escape.</param>

--- a/src/BB84.SourceGenerators/IniFileGenerator.cs
+++ b/src/BB84.SourceGenerators/IniFileGenerator.cs
@@ -24,16 +24,15 @@ namespace BB84.SourceGenerators;
 [Generator(LanguageNames.CSharp)]
 public sealed class IniFileGenerator : IIncrementalGenerator
 {
-	private static readonly string GeneratorAttributeName = typeof(GenerateIniFileAttribute).FullName;
+	private static readonly (string MetadataName, string FullName, string ShortName) AttributeNames =
+		GeneratorHelpers.GetAttributeNames<GenerateIniFileAttribute>();
 	private static readonly string SectionAttributeName = typeof(GenerateIniFileSectionAttribute).FullName;
 	private static readonly string ValueAttributeName = typeof(GenerateIniFileValueAttribute).FullName;
-	private const string AttributeFullName = nameof(GenerateIniFileAttribute);
-	private static readonly string AttributeShortName = GeneratorHelpers.StripAttributeSuffix(AttributeFullName);
 	private static readonly string[] LineBreakSeparators = ["\r\n", "\n"];
 
 	/// <inheritdoc/>
 	public void Initialize(IncrementalGeneratorInitializationContext context)
-		=> GeneratorHelpers.RegisterClassGenerator(context, GeneratorAttributeName, Execute);
+		=> GeneratorHelpers.RegisterClassGenerator(context, AttributeNames.MetadataName, Execute);
 
 	private void Execute(SourceProductionContext context, (ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)? input)
 	{
@@ -644,7 +643,7 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 			{
 				string name = attribute.Name.ToString();
 
-				if (name != AttributeShortName && name != AttributeFullName)
+				if (name != AttributeNames.ShortName && name != AttributeNames.FullName)
 					continue;
 
 				if (attribute.ArgumentList is null)
@@ -817,7 +816,7 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 	{
 		foreach (AttributeData attr in classSymbol.GetAttributes())
 		{
-			if (attr.AttributeClass?.ToDisplayString() == GeneratorAttributeName)
+			if (attr.AttributeClass?.ToDisplayString() == AttributeNames.MetadataName)
 				return attr;
 		}
 

--- a/src/BB84.SourceGenerators/NotificationsGenerator.cs
+++ b/src/BB84.SourceGenerators/NotificationsGenerator.cs
@@ -20,13 +20,12 @@ namespace BB84.SourceGenerators;
 [Generator(LanguageNames.CSharp)]
 public sealed class NotificationsGenerator : IIncrementalGenerator
 {
-	private static readonly string GeneratorAttributeName = typeof(GenerateNotificationsAttribute).FullName;
-	private const string AttributeFullName = nameof(GenerateNotificationsAttribute);
-	private static readonly string AttributeShortName = GeneratorHelpers.StripAttributeSuffix(AttributeFullName);
+	private static readonly (string MetadataName, string FullName, string ShortName) AttributeNames =
+		GeneratorHelpers.GetAttributeNames<GenerateNotificationsAttribute>();
 
 	/// <inheritdoc/>
 	public void Initialize(IncrementalGeneratorInitializationContext context)
-		=> GeneratorHelpers.RegisterClassGenerator(context, GeneratorAttributeName, Execute);
+		=> GeneratorHelpers.RegisterClassGenerator(context, AttributeNames.MetadataName, Execute);
 
 	private void Execute(SourceProductionContext context, (ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)? input)
 	{
@@ -82,7 +81,7 @@ public sealed class NotificationsGenerator : IIncrementalGenerator
 			{
 				string name = attribute.Name.ToString();
 
-				if (name != AttributeShortName && name != AttributeFullName)
+				if (name != AttributeNames.ShortName && name != AttributeNames.FullName)
 					continue;
 
 				if (attribute.ArgumentList is null || attribute.ArgumentList.Arguments.Count == 0)

--- a/src/BB84.SourceGenerators/SingletonGenerator.cs
+++ b/src/BB84.SourceGenerators/SingletonGenerator.cs
@@ -20,13 +20,12 @@ namespace BB84.SourceGenerators;
 [Generator(LanguageNames.CSharp)]
 public sealed class SingletonGenerator : IIncrementalGenerator
 {
-	private const string AttributeFullName = nameof(GenerateSingletonAttribute);
-	private static readonly string AttributeShortName = GeneratorHelpers.StripAttributeSuffix(AttributeFullName);
-	private static readonly string GeneratorAttributeName = typeof(GenerateSingletonAttribute).FullName;
+	private static readonly (string MetadataName, string FullName, string ShortName) AttributeNames =
+		GeneratorHelpers.GetAttributeNames<GenerateSingletonAttribute>();
 
 	/// <inheritdoc/>
 	public void Initialize(IncrementalGeneratorInitializationContext context)
-		=> GeneratorHelpers.RegisterClassGenerator(context, GeneratorAttributeName, Execute);
+		=> GeneratorHelpers.RegisterClassGenerator(context, AttributeNames.MetadataName, Execute);
 
 	private void Execute(SourceProductionContext context, (ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)? input)
 	{
@@ -122,7 +121,7 @@ public sealed class SingletonGenerator : IIncrementalGenerator
 			{
 				string name = attribute.Name.ToString();
 
-				if (name != AttributeShortName && name != AttributeFullName)
+				if (name != AttributeNames.ShortName && name != AttributeNames.FullName)
 					continue;
 
 				if (attribute.ArgumentList is null || attribute.ArgumentList.Arguments.Count == 0)


### PR DESCRIPTION
**Changes:**

- Centralized attribute name extraction using `GeneratorHelpers.GetAttributeNames<TAttribute>()`, replacing manual name handling in all generators.
- Updated all usages to use the new tuple values and removed redundant constants and fields for improved maintainability.

closes #125 