### PR TITLE
fix(docs): expand supported attributes in `GenerateValidator` docs

### DIFF
--- a/src/BB84.SourceGenerators/Attributes/GenerateValidatorAttribute.cs
+++ b/src/BB84.SourceGenerators/Attributes/GenerateValidatorAttribute.cs
@@ -18,6 +18,12 @@ namespace BB84.SourceGenerators.Attributes;
 /// <item><c>MinLengthAttribute</c></item>
 /// <item><c>MaxLengthAttribute</c></item>
 /// <item><c>RegularExpressionAttribute</c></item>
+/// <item><c>EmailAddressAttribute</c></item>
+/// <item><c>UrlAttribute</c></item>
+/// <item><c>PhoneAttribute</c></item>
+/// <item><c>CreditCardAttribute</c></item>
+/// <item><c>CompareAttribute</c></item>
+/// <item>Any custom <c>ValidationAttribute</c> subclass (via <c>IsValid</c> call)</item>
 /// </list>
 /// </para>
 /// </summary>


### PR DESCRIPTION
**Changes:**

- Expanded XML docs for `GenerateValidatorAttribute` to list `EmailAddressAttribute`, `UrlAttribute`, `PhoneAttribute`, `CreditCardAttribute`, `CompareAttribute`, and support for custom `ValidationAttribute` subclasses via `IsValid`.

closes #127 