### PR TITLE
fix: refactor `IsDefinedFast` to static method, update tests

### DIFF
--- a/src/BB84.SourceGenerators/EnumeratorExtensionsGenerator.cs
+++ b/src/BB84.SourceGenerators/EnumeratorExtensionsGenerator.cs
@@ -140,7 +140,7 @@ public sealed class EnumeratorExtensionsGenerator : IIncrementalGenerator
 		sb.AppendLine("/// </summary>");
 		sb.AppendLine("/// <param name=\"name\">The name of the enumeration value to check.</param>");
 		sb.AppendLine("/// <returns>True if the enumeration value is defined; otherwise, false.</returns>");
-		sb.AppendLine($"public static bool IsDefinedFast(this string name)");
+		sb.AppendLine($"public static bool IsDefinedFast(string name)");
 		sb.OpenBrace();
 		sb.AppendLine("return name switch");
 		sb.OpenBrace();

--- a/tests/BB84.SourceGenerators.Tests/EnumeratorExtensionsGeneratorTests.cs
+++ b/tests/BB84.SourceGenerators.Tests/EnumeratorExtensionsGeneratorTests.cs
@@ -47,17 +47,17 @@ public sealed class EnumeratorExtensionsGeneratorTests
 	[TestMethod]
 	public void IsDefinedFastShouldReturnTrueForDefinedNames()
 	{
-		Assert.IsTrue(nameof(GeneratorTestType.None).IsDefinedFast());
-		Assert.IsTrue(nameof(GeneratorTestType.One).IsDefinedFast());
-		Assert.IsTrue(nameof(GeneratorTestType.Two).IsDefinedFast());
-		Assert.IsTrue(nameof(GeneratorTestType.Three).IsDefinedFast());
+		Assert.IsTrue(GeneratorTestTypeExtensions.IsDefinedFast(nameof(GeneratorTestType.None)));
+		Assert.IsTrue(GeneratorTestTypeExtensions.IsDefinedFast(nameof(GeneratorTestType.One)));
+		Assert.IsTrue(GeneratorTestTypeExtensions.IsDefinedFast(nameof(GeneratorTestType.Two)));
+		Assert.IsTrue(GeneratorTestTypeExtensions.IsDefinedFast(nameof(GeneratorTestType.Three)));
 	}
 
 	[TestMethod]
 	public void IsDefinedFastShouldReturnFalseForUndefinedNames()
 	{
-		Assert.IsFalse("UndefinedValue".IsDefinedFast());
-		Assert.IsFalse("AnotherUndefinedValue".IsDefinedFast());
+		Assert.IsFalse(GeneratorTestTypeExtensions.IsDefinedFast("UndefinedValue"));
+		Assert.IsFalse(GeneratorTestTypeExtensions.IsDefinedFast("AnotherUndefinedValue"));
 	}
 
 	[TestMethod]


### PR DESCRIPTION
**Changes:**

- Changed `IsDefinedFast` from a string extension method to a static method accepting a string parameter.
- Updated all test usages to call the static method on the extensions class directly.

closes #124 