### PR TITLE
fix: refactor `GetNamesFast`/`GetValuesFast` to static methods

### DIFF
--- a/src/BB84.SourceGenerators/EnumeratorExtensionsGenerator.cs
+++ b/src/BB84.SourceGenerators/EnumeratorExtensionsGenerator.cs
@@ -161,9 +161,8 @@ public sealed class EnumeratorExtensionsGenerator : IIncrementalGenerator
 		sb.AppendLine("/// <summary>");
 		sb.AppendLine($"/// Returns the names of the <see cref=\"{enumName}\"/> enumeration as an collection of strings.");
 		sb.AppendLine("/// </summary>");
-		sb.AppendLine("/// <param name=\"value\">The enumeration value to get the names for.</param>");
 		sb.AppendLine("/// <returns>An array of strings containing the names of the enumeration values.</returns>");
-		sb.AppendLine($"public static IEnumerable<string> GetNamesFast(this {enumName} value)");
+		sb.AppendLine($"public static IEnumerable<string> GetNamesFast()");
 		sb.OpenBrace();
 		sb.AppendLine("return new[]");
 		sb.OpenBrace();
@@ -183,9 +182,8 @@ public sealed class EnumeratorExtensionsGenerator : IIncrementalGenerator
 		sb.AppendLine("/// <summary>");
 		sb.AppendLine($"/// Returns the values of the <see cref=\"{enumName}\"/> enumeration.");
 		sb.AppendLine("/// </summary>");
-		sb.AppendLine("/// <param name=\"value\">The enumeration value to get the values for.</param>");
 		sb.AppendLine("/// <returns>An collection of the enumeration values.</returns>");
-		sb.AppendLine($"public static IEnumerable<{enumName}> GetValuesFast(this {enumName} value)");
+		sb.AppendLine($"public static IEnumerable<{enumName}> GetValuesFast()");
 		sb.OpenBrace();
 		sb.AppendLine("return new[]");
 		sb.OpenBrace();

--- a/tests/BB84.SourceGenerators.Tests/EnumeratorExtensionsGeneratorTests.cs
+++ b/tests/BB84.SourceGenerators.Tests/EnumeratorExtensionsGeneratorTests.cs
@@ -16,7 +16,7 @@ public sealed class EnumeratorExtensionsGeneratorTests
 	public void GetNamesFastShouldReturnCorrectNames()
 	{
 		List<string> expectedNames = [nameof(GeneratorTestType.None), nameof(GeneratorTestType.One), nameof(GeneratorTestType.Two), nameof(GeneratorTestType.Three)];
-		List<string> actualNames = [.. GeneratorTestType.None.GetNamesFast()];
+		List<string> actualNames = [.. GeneratorTestTypeExtensions.GetNamesFast()];
 		CollectionAssert.AreEqual(expectedNames, actualNames);
 	}
 
@@ -24,7 +24,7 @@ public sealed class EnumeratorExtensionsGeneratorTests
 	public void GetValuesFastShouldReturnCorrectValues()
 	{
 		List<GeneratorTestType> expectedValues = [GeneratorTestType.None, GeneratorTestType.One, GeneratorTestType.Two, GeneratorTestType.Three];
-		List<GeneratorTestType> actualValues = [.. GeneratorTestType.None.GetValuesFast()];
+		List<GeneratorTestType> actualValues = [.. GeneratorTestTypeExtensions.GetValuesFast()];
 		CollectionAssert.AreEqual(expectedValues, actualValues);
 	}
 


### PR DESCRIPTION
**Changes:**

- Changed `GetNamesFast` and `GetValuesFast` from instance extension methods to static methods without parameters.
- Updated unit tests to call these methods via the static `GeneratorTestTypeExtensions` class.

closes #123 