### PR TITLE
feat(ToString): Add `[ToStringFormat]` for per-property `ToString` formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -669,12 +669,17 @@ Generates a `ToString()` override for classes, returning a formatted string cont
 
 ```csharp
 [GenerateToString(params string[] excludeProperties)]
+[ToStringFormat(string format)]  // per-property
 ```
 
 **Parameters:**
 
 - `excludeProperties` - Optional list of property names to exclude from the generated `ToString()` output
 - `CollectionFormat` - Controls how collection properties are rendered (named argument, default: `CollectionFormat.Count`)
+
+**Per-Property Formatting:**
+
+- `[ToStringFormat("format")]` - Applied to individual properties to specify a custom format string. The format is passed to the property's `ToString(string)` method at runtime (e.g., `"yyyy-MM-dd"` for dates, `"C2"` for currency, `"F2"` for fixed-point).
 
 **Collection Format Modes:**
 
@@ -726,6 +731,19 @@ public partial class TeamSummary
     public string Name { get; set; }
     public List<string> Members { get; set; }
 }
+
+// Per-property format specifiers
+[GenerateToString]
+public partial class Order
+{
+    public int Id { get; set; }
+
+    [ToStringFormat("yyyy-MM-dd")]
+    public DateTime CreatedAt { get; set; }
+
+    [ToStringFormat("C2")]
+    public decimal Total { get; set; }
+}
 ```
 
 #### Generated Code
@@ -736,6 +754,7 @@ The generator creates a `ToString()` override on the partial class that:
 - Excludes properties specified in the attribute parameter
 - Formats output as `ClassName { Prop1 = val1, Prop2 = val2 }`
 - Returns `ClassName { }` when all properties are excluded
+- For properties decorated with `[ToStringFormat]`, uses the format specifier in the interpolated string (e.g., `{CreatedAt:yyyy-MM-dd}`)
 - For collection properties, emits inline formatting based on `CollectionFormat`:
   - `Count`: `Count = N`
   - `Elements`: `[item1, item2]` for arrays/lists, `{key1: val1, key2: val2}` for dictionaries
@@ -785,6 +804,16 @@ var summary = new TeamSummary
 
 Console.WriteLine(summary.ToString());
 // Output: TeamSummary { Name = Beta, Members = Count = 3 }
+
+var order = new Order
+{
+    Id = 1,
+    CreatedAt = new DateTime(2025, 1, 15),
+    Total = 1234.56m
+};
+
+Console.WriteLine(order.ToString());
+// Output: Order { Id = 1, CreatedAt = 2025-01-15, Total = $1,234.56 }
 ```
 
 ### 7. Validator Generator

--- a/src/BB84.SourceGenerators/AttributeSourceGenerator.cs
+++ b/src/BB84.SourceGenerators/AttributeSourceGenerator.cs
@@ -78,6 +78,9 @@ public sealed class AttributeSourceGenerator : IIncrementalGenerator
 	private static readonly string GenerateToStringAttributeSource =
 		AttributeSourceRewriter.ReadAndTransform("GenerateToStringAttribute.cs");
 
+	private static readonly string ToStringFormatAttributeSource =
+		AttributeSourceRewriter.ReadAndTransform("ToStringFormatAttribute.cs");
+
 	private static readonly string GenerateValidatorAttributeSource =
 		AttributeSourceRewriter.ReadAndTransform("GenerateValidatorAttribute.cs");
 
@@ -113,6 +116,7 @@ public sealed class AttributeSourceGenerator : IIncrementalGenerator
 			ctx.AddSource("GenerateSingletonAttribute.g.cs", GenerateSingletonAttributeSource);
 			ctx.AddSource("GenerateToStringAttribute.g.cs", GenerateToStringAttributeSource);
 			ctx.AddSource("GenerateValidatorAttribute.g.cs", GenerateValidatorAttributeSource);
+			ctx.AddSource("ToStringFormatAttribute.g.cs", ToStringFormatAttributeSource);
 			ctx.AddSource("PropertyMappingAttribute.g.cs", PropertyMappingAttributeSource);
 		});
 	}

--- a/src/BB84.SourceGenerators/Attributes/ToStringFormatAttribute.cs
+++ b/src/BB84.SourceGenerators/Attributes/ToStringFormatAttribute.cs
@@ -1,0 +1,20 @@
+// Copyright: 2026 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+namespace BB84.SourceGenerators.Attributes;
+
+/// <summary>
+/// Specifies a custom format string for a property in the generated <c>ToString()</c> output.
+/// The format string is passed to the property's <c>ToString(string)</c> method at runtime.
+/// </summary>
+/// <param name="format">The format string to use (e.g., <c>"yyyy-MM-dd"</c> for dates or <c>"C2"</c> for currency).</param>
+[AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
+internal sealed class ToStringFormatAttribute(string format) : Attribute
+{
+	/// <summary>
+	/// Gets the format string to use for the property in the generated <c>ToString()</c> output.
+	/// </summary>
+	public string Format { get; } = format;
+}

--- a/src/BB84.SourceGenerators/BB84.SourceGenerators.csproj
+++ b/src/BB84.SourceGenerators/BB84.SourceGenerators.csproj
@@ -52,6 +52,7 @@
 		<EmbeddedResource Include="Attributes\GenerateSingletonAttribute.cs" LogicalName="GenerateSingletonAttribute.cs" />
 		<EmbeddedResource Include="Attributes\GenerateToStringAttribute.cs" LogicalName="GenerateToStringAttribute.cs" />
 		<EmbeddedResource Include="Attributes\GenerateValidatorAttribute.cs" LogicalName="GenerateValidatorAttribute.cs" />
+		<EmbeddedResource Include="Attributes\ToStringFormatAttribute.cs" LogicalName="ToStringFormatAttribute.cs" />
 		<EmbeddedResource Include="Attributes\PropertyMappingAttribute.cs" LogicalName="PropertyMappingAttribute.cs" />
 	</ItemGroup>
 	<ItemGroup>

--- a/src/BB84.SourceGenerators/Helpers/GeneratorHelpers.cs
+++ b/src/BB84.SourceGenerators/Helpers/GeneratorHelpers.cs
@@ -257,13 +257,18 @@ internal static class GeneratorHelpers
 	/// <param name="detectCollections">
 	/// When <see langword="true"/>, detects collection types and sets <see cref="PropertyDescriptor.CollectionKind"/> accordingly.
 	/// </param>
+	/// <param name="toStringFormatAttributeName">
+	/// When not <see langword="null"/>, checks whether the property is decorated with the specified attribute
+	/// and sets <see cref="PropertyDescriptor.FormatString"/> accordingly.
+	/// </param>
 	/// <returns>An immutable array of <see cref="PropertyDescriptor"/> instances.</returns>
 	internal static ImmutableArray<PropertyDescriptor> GetPropertyDescriptors(
 		INamedTypeSymbol classSymbol,
 		HashSet<string>? excludedProperties = null,
 		bool requireSetter = false,
 		string? cloneableAttributeName = null,
-		bool detectCollections = false)
+		bool detectCollections = false,
+		string? toStringFormatAttributeName = null)
 	{
 		ImmutableArray<PropertyDescriptor>.Builder builder = ImmutableArray.CreateBuilder<PropertyDescriptor>();
 
@@ -286,6 +291,7 @@ internal static class GeneratorHelpers
 			bool isElementCloneable = false;
 			string? dictionaryValueTypeName = null;
 			bool isDictionaryValueCloneable = false;
+			string? formatString = null;
 
 			if (cloneableAttributeName is not null)
 			{
@@ -299,6 +305,20 @@ internal static class GeneratorHelpers
 				}
 			}
 
+			if (toStringFormatAttributeName is not null)
+			{
+				foreach (AttributeData attributeData in propertySymbol.GetAttributes())
+				{
+					if (attributeData.AttributeClass?.ToDisplayString() == toStringFormatAttributeName
+						&& attributeData.ConstructorArguments.Length == 1
+						&& attributeData.ConstructorArguments[0].Value is string fmt)
+					{
+						formatString = fmt;
+						break;
+					}
+				}
+			}
+
 			// Detect collection types when explicitly requested or when cloneability checks are active
 			if (cloneableAttributeName is not null || detectCollections)
 			{
@@ -306,7 +326,7 @@ internal static class GeneratorHelpers
 					DetectCollectionKind(propertySymbol.Type, cloneableAttributeName);
 			}
 
-			builder.Add(new PropertyDescriptor(propertySymbol.Name, typeName, isValueType, isNullable, isCloneable, collectionKind, elementTypeName, isElementCloneable, dictionaryValueTypeName, isDictionaryValueCloneable));
+			builder.Add(new PropertyDescriptor(propertySymbol.Name, typeName, isValueType, isNullable, isCloneable, collectionKind, elementTypeName, isElementCloneable, dictionaryValueTypeName, isDictionaryValueCloneable, formatString));
 		}
 
 		return builder.ToImmutable();

--- a/src/BB84.SourceGenerators/Models/PropertyDescriptor.cs
+++ b/src/BB84.SourceGenerators/Models/PropertyDescriptor.cs
@@ -9,7 +9,7 @@ namespace BB84.SourceGenerators.Models;
 /// Describes a property discovered during source generation, carrying metadata
 /// needed by multiple generators (Equality, Cloneable, Builder, ToString).
 /// </summary>
-internal sealed record PropertyDescriptor(string Name, string TypeName, bool IsValueType, bool IsNullable, bool IsCloneable, CollectionKind CollectionKind = CollectionKind.None, string? ElementTypeName = null, bool IsElementCloneable = false, string? DictionaryValueTypeName = null, bool IsDictionaryValueCloneable = false)
+internal sealed record PropertyDescriptor(string Name, string TypeName, bool IsValueType, bool IsNullable, bool IsCloneable, CollectionKind CollectionKind = CollectionKind.None, string? ElementTypeName = null, bool IsElementCloneable = false, string? DictionaryValueTypeName = null, bool IsDictionaryValueCloneable = false, string? FormatString = null)
 {
 	/// <summary>
 	/// Gets the name of the property.
@@ -68,4 +68,10 @@ internal sealed record PropertyDescriptor(string Name, string TypeName, bool IsV
 	/// <c>[GenerateCloneable]</c> and supports deep cloning.
 	/// </summary>
 	public bool IsDictionaryValueCloneable { get; } = IsDictionaryValueCloneable;
+
+	/// <summary>
+	/// Gets the optional format string for the property, specified via <c>[ToStringFormat]</c>.
+	/// When not <see langword="null"/>, the generated <c>ToString()</c> uses this format specifier.
+	/// </summary>
+	public string? FormatString { get; } = FormatString;
 }

--- a/src/BB84.SourceGenerators/ToStringGenerator.cs
+++ b/src/BB84.SourceGenerators/ToStringGenerator.cs
@@ -25,6 +25,8 @@ public sealed class ToStringGenerator : IIncrementalGenerator
 	private static readonly (string MetadataName, string FullName, string ShortName) AttributeNames =
 		GeneratorHelpers.GetAttributeNames<GenerateToStringAttribute>();
 
+	private static readonly string ToStringFormatAttributeName = typeof(ToStringFormatAttribute).FullName;
+
 	/// <inheritdoc/>
 	public void Initialize(IncrementalGeneratorInitializationContext context)
 		=> GeneratorHelpers.RegisterClassGenerator(context, AttributeNames.MetadataName, Execute);
@@ -36,7 +38,7 @@ public sealed class ToStringGenerator : IIncrementalGenerator
 
 		CollectionFormat collectionFormat = GetCollectionFormat(ctx.ClassDeclaration, ctx.SemanticModel);
 		HashSet<string> excludedProperties = GeneratorHelpers.GetExcludedProperties(ctx.ClassDeclaration, ctx.SemanticModel, nameof(GenerateToStringAttribute));
-		ImmutableArray<PropertyDescriptor> properties = GeneratorHelpers.GetPropertyDescriptors(ctx.ClassSymbol, excludedProperties, detectCollections: true);
+		ImmutableArray<PropertyDescriptor> properties = GeneratorHelpers.GetPropertyDescriptors(ctx.ClassSymbol, excludedProperties, detectCollections: true, toStringFormatAttributeName: ToStringFormatAttributeName);
 
 		SourceBuilder sb = new();
 
@@ -109,7 +111,9 @@ public sealed class ToStringGenerator : IIncrementalGenerator
 
 			string token = properties[i].CollectionKind != CollectionKind.None
 				? $"{properties[i].Name.ToLowerInvariant()}"
-				: properties[i].Name;
+				: properties[i].FormatString is not null
+					? $"{properties[i].Name}:{properties[i].FormatString}"
+					: properties[i].Name;
 
 			format.Append($"{{nameof({properties[i].Name})}} = {{{token}}}");
 		}

--- a/tests/BB84.SourceGenerators.Tests/AttributeSourceGeneratorTests.cs
+++ b/tests/BB84.SourceGenerators.Tests/AttributeSourceGeneratorTests.cs
@@ -53,6 +53,7 @@ public sealed class AttributeSourceGeneratorAttributeCoverageTests
 			nameof(GenerateValidatorAttribute),
 			nameof(GenerateAutoMapperAttribute),
 			nameof(PropertyMappingAttribute),
+			nameof(ToStringFormatAttribute),
 		];
 
 		Assert.HasCount(expectedAttributeClassNames.Length, GeneratedAttributeSources,

--- a/tests/BB84.SourceGenerators.Tests/ToStringGeneratorTests.cs
+++ b/tests/BB84.SourceGenerators.Tests/ToStringGeneratorTests.cs
@@ -212,6 +212,42 @@ public sealed class ToStringGeneratorTests
 
 		Assert.AreEqual(expected, result);
 	}
+
+	[TestMethod]
+	public void ToStringShouldApplyCustomFormatSpecifiers()
+	{
+		ToStringFormatTestModel model = new()
+		{
+			CreatedAt = new DateTime(2025, 1, 15),
+			Total = 1234.56m
+		};
+
+		string? result = model.ToString();
+		string expected = nameof(ToStringFormatTestModel) + " { " +
+			"CreatedAt = 2025-01-15, " +
+			"Total = " + $"{model.Total:F2}" + " }";
+
+		Assert.AreEqual(expected, result);
+	}
+
+	[TestMethod]
+	public void ToStringShouldMixFormattedAndUnformattedProperties()
+	{
+		ToStringMixedFormatTestModel model = new()
+		{
+			Name = "Order",
+			Amount = 99.5m,
+			Created = new DateTime(2025, 6, 1, 14, 30, 0)
+		};
+
+		string? result = model.ToString();
+		string expected = nameof(ToStringMixedFormatTestModel) + " { " +
+			"Name = Order, " +
+			"Amount = " + $"{model.Amount:C2}" + ", " +
+			"Created = 2025-06-01 }";
+
+		Assert.AreEqual(expected, result);
+	}
 }
 
 [GenerateToString]
@@ -276,4 +312,26 @@ public partial class ToStringArrayTestModel
 {
 	public string? Name { get; set; }
 	public string[]? Tags { get; set; }
+}
+
+[GenerateToString]
+public partial class ToStringFormatTestModel
+{
+	[ToStringFormat("yyyy-MM-dd")]
+	public DateTime CreatedAt { get; set; }
+
+	[ToStringFormat("F2")]
+	public decimal Total { get; set; }
+}
+
+[GenerateToString]
+public partial class ToStringMixedFormatTestModel
+{
+	public string? Name { get; set; }
+
+	[ToStringFormat("C2")]
+	public decimal Amount { get; set; }
+
+	[ToStringFormat("yyyy-MM-dd")]
+	public DateTime Created { get; set; }
 }


### PR DESCRIPTION
**Changes:**

- Introduce `[ToStringFormat]` attribute to enable custom format strings for individual properties in generated `ToString()` methods.
- Updated generator logic, `PropertyDescriptor`, and tests to support and verify formatted output.
- Enhanced `README.md` with usage examples and documentation.

closes #137 