### PR TITLE
feat(ToString): add `Separator` option to `GenerateToStringAttribute`

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,6 +676,7 @@ Generates a `ToString()` override for classes, returning a formatted string cont
 
 - `excludeProperties` - Optional list of property names to exclude from the generated `ToString()` output
 - `CollectionFormat` - Controls how collection properties are rendered (named argument, default: `CollectionFormat.Count`)
+- `Separator` - Custom separator string between properties (named argument, default: `", "`)
 
 **Per-Property Formatting:**
 
@@ -743,6 +744,14 @@ public partial class Order
 
     [ToStringFormat("C2")]
     public decimal Total { get; set; }
+}
+
+// Custom property separator
+[GenerateToString(Separator = " | ")]
+public partial class Config
+{
+    public string Host { get; set; }
+    public int Port { get; set; }
 }
 ```
 
@@ -814,6 +823,15 @@ var order = new Order
 
 Console.WriteLine(order.ToString());
 // Output: Order { Id = 1, CreatedAt = 2025-01-15, Total = $1,234.56 }
+
+var config = new Config
+{
+    Host = "localhost",
+    Port = 8080
+};
+
+Console.WriteLine(config.ToString());
+// Output: Config { Host = localhost | Port = 8080 }
 ```
 
 ### 7. Validator Generator

--- a/src/BB84.SourceGenerators/Attributes/GenerateToStringAttribute.cs
+++ b/src/BB84.SourceGenerators/Attributes/GenerateToStringAttribute.cs
@@ -52,4 +52,10 @@ internal sealed class GenerateToStringAttribute(params string[] excludePropertie
 	/// Defaults to <see cref="CollectionFormat.Count"/>.
 	/// </summary>
 	public CollectionFormat CollectionFormat { get; set; } = CollectionFormat.Count;
+
+	/// <summary>
+	/// Gets or sets the separator string used between properties in the generated <c>ToString()</c> output.
+	/// Defaults to <c>", "</c>.
+	/// </summary>
+	public string Separator { get; set; } = ", ";
 }

--- a/src/BB84.SourceGenerators/ToStringGenerator.cs
+++ b/src/BB84.SourceGenerators/ToStringGenerator.cs
@@ -37,6 +37,7 @@ public sealed class ToStringGenerator : IIncrementalGenerator
 			return;
 
 		CollectionFormat collectionFormat = GetCollectionFormat(ctx.ClassDeclaration, ctx.SemanticModel);
+		string separator = GetSeparator(ctx.ClassDeclaration, ctx.SemanticModel);
 		HashSet<string> excludedProperties = GeneratorHelpers.GetExcludedProperties(ctx.ClassDeclaration, ctx.SemanticModel, nameof(GenerateToStringAttribute));
 		ImmutableArray<PropertyDescriptor> properties = GeneratorHelpers.GetPropertyDescriptors(ctx.ClassSymbol, excludedProperties, detectCollections: true, toStringFormatAttributeName: ToStringFormatAttributeName);
 
@@ -50,7 +51,7 @@ public sealed class ToStringGenerator : IIncrementalGenerator
 		sb.OpenNamespace(ctx.NamespaceName);
 		sb.OpenOuterClasses(ctx.OuterClasses);
 
-		AppendPartialClass(sb, ctx.ClassName, ctx.Accessibility, properties, collectionFormat);
+		AppendPartialClass(sb, ctx.ClassName, ctx.Accessibility, properties, collectionFormat, separator);
 
 		sb.CloseOuterClasses(ctx.OuterClasses);
 		sb.CloseNamespace();
@@ -62,7 +63,7 @@ public sealed class ToStringGenerator : IIncrementalGenerator
 		context.AddSource(hintName, sb.ToString());
 	}
 
-	private static void AppendPartialClass(SourceBuilder sb, string className, string accessibility, ImmutableArray<PropertyDescriptor> properties, CollectionFormat collectionFormat)
+	private static void AppendPartialClass(SourceBuilder sb, string className, string accessibility, ImmutableArray<PropertyDescriptor> properties, CollectionFormat collectionFormat, string separator)
 	{
 		bool hasDictionary = collectionFormat == CollectionFormat.Elements
 			&& properties.Any(static p => p.CollectionKind == CollectionKind.Dictionary);
@@ -86,7 +87,7 @@ public sealed class ToStringGenerator : IIncrementalGenerator
 				sb.AppendLine($"string {prop.Name.ToLowerInvariant()} = {BuildCollectionFormatExpression(prop, collectionFormat)};");
 			}
 
-			sb.AppendLine($"return $\"{className} {{{{ {BuildFormatString(properties)} }}}}\";");
+			sb.AppendLine($"return $\"{className} {{{{ {BuildFormatString(properties, separator)} }}}}\";");
 		}
 
 		sb.CloseBrace();
@@ -100,14 +101,14 @@ public sealed class ToStringGenerator : IIncrementalGenerator
 		sb.CloseClass();
 	}
 
-	private static string BuildFormatString(ImmutableArray<PropertyDescriptor> properties)
+	private static string BuildFormatString(ImmutableArray<PropertyDescriptor> properties, string separator)
 	{
 		StringBuilder format = new();
 
 		for (int i = 0; i < properties.Length; i++)
 		{
 			if (i > 0)
-				format.Append(", ");
+				format.Append(separator);
 
 			string token = properties[i].CollectionKind != CollectionKind.None
 				? $"{properties[i].Name.ToLowerInvariant()}"
@@ -174,6 +175,40 @@ public sealed class ToStringGenerator : IIncrementalGenerator
 		sb.Outdent();
 		sb.AppendLine("return \"{\" + string.Join(\", \", parts) + \"}\";");
 		sb.CloseBrace();
+	}
+
+	private static string GetSeparator(ClassDeclarationSyntax classDeclaration, SemanticModel semanticModel)
+	{
+		foreach (AttributeListSyntax attributeList in classDeclaration.AttributeLists)
+		{
+			foreach (AttributeSyntax attribute in attributeList.Attributes)
+			{
+				string name = attribute.Name.ToString();
+
+				if (name != AttributeNames.ShortName && name != AttributeNames.FullName)
+					continue;
+
+				if (attribute.ArgumentList is null)
+					return ", ";
+
+				foreach (AttributeArgumentSyntax arg in attribute.ArgumentList.Arguments)
+				{
+					if (arg.NameEquals?.Name.Identifier.Text != nameof(GenerateToStringAttribute.Separator))
+						continue;
+
+					Optional<object?> value = semanticModel.GetConstantValue(arg.Expression);
+
+					if (value.HasValue && value.Value is string stringValue)
+						return stringValue;
+
+					break;
+				}
+
+				return ", ";
+			}
+		}
+
+		return ", ";
 	}
 
 	private static CollectionFormat GetCollectionFormat(ClassDeclarationSyntax classDeclaration, SemanticModel semanticModel)

--- a/tests/BB84.SourceGenerators.Tests/ToStringGeneratorTests.cs
+++ b/tests/BB84.SourceGenerators.Tests/ToStringGeneratorTests.cs
@@ -130,7 +130,7 @@ public sealed class ToStringGeneratorTests
 		ToStringCollectionElementsTestModel model = new()
 		{
 			Name = "Alpha",
-			Members = new List<string> { "Alice", "Bob", "Charlie" },
+			Members = ["Alice", "Bob", "Charlie"],
 			Scores = new Dictionary<string, int> { ["Alice"] = 10, ["Bob"] = 20 }
 		};
 
@@ -248,6 +248,40 @@ public sealed class ToStringGeneratorTests
 
 		Assert.AreEqual(expected, result);
 	}
+
+	[TestMethod]
+	public void ToStringShouldUseCustomSeparator()
+	{
+		ToStringCustomSeparatorTestModel model = new()
+		{
+			Host = "localhost",
+			Port = 8080
+		};
+
+		string? result = model.ToString();
+		string expected = nameof(ToStringCustomSeparatorTestModel) + " { " +
+			"Host = localhost | " +
+			"Port = 8080 }";
+
+		Assert.AreEqual(expected, result);
+	}
+
+	[TestMethod]
+	public void ToStringShouldUseDefaultSeparatorWhenNotSpecified()
+	{
+		ToStringTestModel model = new()
+		{
+			Id = 1,
+			Name = "Test",
+			Description = "Desc",
+			Price = 10.0,
+			IsActive = true
+		};
+
+		string? result = model.ToString();
+
+		Assert.Contains(", ", result);
+	}
 }
 
 [GenerateToString]
@@ -334,4 +368,11 @@ public partial class ToStringMixedFormatTestModel
 
 	[ToStringFormat("yyyy-MM-dd")]
 	public DateTime Created { get; set; }
+}
+
+[GenerateToString(Separator = " | ")]
+public partial class ToStringCustomSeparatorTestModel
+{
+	public string? Host { get; set; }
+	public int Port { get; set; }
 }


### PR DESCRIPTION
**Changes:**

- Introduce `Separator` property for `GenerateToStringAttribute` to customize property separators in generated `ToString()` methods (default: ", ").
- Update generator logic, documentation, and add tests for custom and default separator scenarios.
- Add `ToStringCustomSeparatorTestModel` for demonstration and testing.

closes #138 