### PR TITLE
feat(ToString): add `NullPlaceholder` support to `GenerateToStringAttribute`

### DIFF
--- a/README.md
+++ b/README.md
@@ -678,6 +678,7 @@ Generates a `ToString()` override for classes, returning a formatted string cont
 - `CollectionFormat` - Controls how collection properties are rendered (named argument, default: `CollectionFormat.Count`)
 - `Separator` - Custom separator string between properties (named argument, default: `", "`)
 - `Formattable` - When `true`, generates an `IFormattable` implementation so the class participates in composite formatting with custom `IFormatProvider` support (named argument, default: `false`)
+- `NullPlaceholder` - When set, nullable properties with a `null` value render this string instead of an empty string (named argument, default: `null` — empty string behavior). Common values: `"null"`, `"<null>"`
 
 **Per-Property Formatting:**
 
@@ -763,6 +764,15 @@ public partial class Invoice
     public decimal Total { get; set; }
     public DateTime IssuedAt { get; set; }
 }
+
+// Explicit null rendering for nullable properties
+[GenerateToString(NullPlaceholder = "null")]
+public partial class Person
+{
+    public int Id { get; set; }
+    public string? Name { get; set; }
+    public int? Age { get; set; }
+}
 ```
 
 #### Generated Code
@@ -780,6 +790,7 @@ The generator creates a `ToString()` override on the partial class that:
   - `TypeAndCount`: `TypeName (Count = N)`
 - For dictionary properties in `Elements` mode, emits a private generic helper `DictionaryToString<TKey, TValue>`
 - When `Formattable = true`, implements `IFormattable` with `ToString(string?, IFormatProvider?)` — properties whose types implement `IFormattable` receive the `formatProvider`; others use their default `ToString()`
+- When `NullPlaceholder` is set, nullable properties with a `null` value emit `Property?.ToString() ?? "placeholder"` instead of the raw interpolation slot; `[ToStringFormat]` is preserved as an explicit `.ToString("fmt")` call
 
 #### Usage Example
 
@@ -857,6 +868,14 @@ Console.WriteLine(invoice.ToString(null, CultureInfo.InvariantCulture));
 
 // Works with string.Format and interpolated strings
 Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "{0}", invoice));
+
+var person = new Person { Id = 1, Name = null, Age = null };
+Console.WriteLine(person.ToString());
+// Output: Person { Id = 1, Name = null, Age = null }
+
+var personWithValues = new Person { Id = 2, Name = "John", Age = 30 };
+Console.WriteLine(personWithValues.ToString());
+// Output: Person { Id = 2, Name = John, Age = 30 }
 ```
 
 ### 7. Validator Generator

--- a/src/BB84.SourceGenerators/Attributes/GenerateToStringAttribute.cs
+++ b/src/BB84.SourceGenerators/Attributes/GenerateToStringAttribute.cs
@@ -66,4 +66,11 @@ internal sealed class GenerateToStringAttribute(params string[] excludePropertie
 	/// Defaults to <see langword="false"/>.
 	/// </summary>
 	public bool Formattable { get; set; }
+
+	/// <summary>
+	/// Gets or sets the placeholder string rendered when a nullable property value is <see langword="null"/>.
+	/// When <see langword="null"/> (the default), null values produce an empty string (standard interpolation behavior).
+	/// Common values: <c>"null"</c>, <c>"&lt;null&gt;"</c>.
+	/// </summary>
+	public string? NullPlaceholder { get; set; }
 }

--- a/src/BB84.SourceGenerators/ToStringGenerator.cs
+++ b/src/BB84.SourceGenerators/ToStringGenerator.cs
@@ -39,6 +39,7 @@ public sealed class ToStringGenerator : IIncrementalGenerator
 		CollectionFormat collectionFormat = GetCollectionFormat(ctx.ClassDeclaration, ctx.SemanticModel);
 		string separator = GetSeparator(ctx.ClassDeclaration, ctx.SemanticModel);
 		bool formattable = GetFormattable(ctx.ClassDeclaration, ctx.SemanticModel);
+		string? nullPlaceholder = GetNullPlaceholder(ctx.ClassDeclaration, ctx.SemanticModel);
 		HashSet<string> excludedProperties = GeneratorHelpers.GetExcludedProperties(ctx.ClassDeclaration, ctx.SemanticModel, nameof(GenerateToStringAttribute));
 		ImmutableArray<PropertyDescriptor> properties = GeneratorHelpers.GetPropertyDescriptors(ctx.ClassSymbol, excludedProperties, detectCollections: true, toStringFormatAttributeName: ToStringFormatAttributeName);
 
@@ -52,7 +53,7 @@ public sealed class ToStringGenerator : IIncrementalGenerator
 		sb.OpenNamespace(ctx.NamespaceName);
 		sb.OpenOuterClasses(ctx.OuterClasses);
 
-		AppendPartialClass(sb, ctx.ClassName, ctx.Accessibility, properties, collectionFormat, separator, formattable);
+		AppendPartialClass(sb, ctx.ClassName, ctx.Accessibility, properties, collectionFormat, separator, formattable, nullPlaceholder);
 
 		sb.CloseOuterClasses(ctx.OuterClasses);
 		sb.CloseNamespace();
@@ -64,7 +65,7 @@ public sealed class ToStringGenerator : IIncrementalGenerator
 		context.AddSource(hintName, sb.ToString());
 	}
 
-	private static void AppendPartialClass(SourceBuilder sb, string className, string accessibility, ImmutableArray<PropertyDescriptor> properties, CollectionFormat collectionFormat, string separator, bool formattable)
+	private static void AppendPartialClass(SourceBuilder sb, string className, string accessibility, ImmutableArray<PropertyDescriptor> properties, CollectionFormat collectionFormat, string separator, bool formattable, string? nullPlaceholder)
 	{
 		bool hasDictionary = collectionFormat == CollectionFormat.Elements
 			&& properties.Any(static p => p.CollectionKind == CollectionKind.Dictionary);
@@ -100,7 +101,7 @@ public sealed class ToStringGenerator : IIncrementalGenerator
 					sb.AppendLine($"string {prop.Name.ToLowerInvariant()} = {BuildCollectionFormatExpression(prop, collectionFormat)};");
 				}
 
-				sb.AppendLine($"return $\"{className} {{{{ {BuildFormattableFormatString(properties, separator)} }}}}\";");
+				sb.AppendLine($"return $\"{className} {{{{ {BuildFormattableFormatString(properties, separator, nullPlaceholder)} }}}}\";");
 			}
 
 			sb.CloseBrace();
@@ -125,7 +126,7 @@ public sealed class ToStringGenerator : IIncrementalGenerator
 					sb.AppendLine($"string {prop.Name.ToLowerInvariant()} = {BuildCollectionFormatExpression(prop, collectionFormat)};");
 				}
 
-				sb.AppendLine($"return $\"{className} {{{{ {BuildFormatString(properties, separator)} }}}}\";");
+				sb.AppendLine($"return $\"{className} {{{{ {BuildFormatString(properties, separator, nullPlaceholder)} }}}}\";");
 			}
 
 			sb.CloseBrace();
@@ -140,7 +141,7 @@ public sealed class ToStringGenerator : IIncrementalGenerator
 		sb.CloseClass();
 	}
 
-	private static string BuildFormatString(ImmutableArray<PropertyDescriptor> properties, string separator)
+	private static string BuildFormatString(ImmutableArray<PropertyDescriptor> properties, string separator, string? nullPlaceholder)
 	{
 		StringBuilder format = new();
 
@@ -149,11 +150,25 @@ public sealed class ToStringGenerator : IIncrementalGenerator
 			if (i > 0)
 				format.Append(separator);
 
-			string token = properties[i].CollectionKind != CollectionKind.None
-				? $"{properties[i].Name.ToLowerInvariant()}"
-				: properties[i].FormatString is not null
+			string token;
+
+			if (properties[i].CollectionKind != CollectionKind.None)
+			{
+				token = properties[i].Name.ToLowerInvariant();
+			}
+			else if (nullPlaceholder is not null && properties[i].IsNullable)
+			{
+				string escaped = GeneratorHelpers.EscapeString(nullPlaceholder);
+				token = properties[i].FormatString is not null
+					? $"({properties[i].Name}?.ToString(\"{properties[i].FormatString}\") ?? \"{escaped}\")"
+					: $"{properties[i].Name}?.ToString() ?? \"{escaped}\"";
+			}
+			else
+			{
+				token = properties[i].FormatString is not null
 					? $"{properties[i].Name}:{properties[i].FormatString}"
 					: properties[i].Name;
+			}
 
 			format.Append($"{{nameof({properties[i].Name})}} = {{{token}}}");
 		}
@@ -161,7 +176,7 @@ public sealed class ToStringGenerator : IIncrementalGenerator
 		return format.ToString();
 	}
 
-	private static string BuildFormattableFormatString(ImmutableArray<PropertyDescriptor> properties, string separator)
+	private static string BuildFormattableFormatString(ImmutableArray<PropertyDescriptor> properties, string separator, string? nullPlaceholder)
 	{
 		StringBuilder format = new();
 
@@ -178,12 +193,28 @@ public sealed class ToStringGenerator : IIncrementalGenerator
 			}
 			else if (properties[i].IsFormattable)
 			{
-				string nullConditional = properties[i].IsNullable ? "?" : "";
-				format.Append($"{{{properties[i].Name}{nullConditional}.ToString(format, formatProvider)}}");
+				if (nullPlaceholder is not null && properties[i].IsNullable)
+				{
+					string escaped = GeneratorHelpers.EscapeString(nullPlaceholder);
+					format.Append($"{{({properties[i].Name}?.ToString(format, formatProvider) ?? \"{escaped}\")}}");
+				}
+				else
+				{
+					string nullConditional = properties[i].IsNullable ? "?" : "";
+					format.Append($"{{{properties[i].Name}{nullConditional}.ToString(format, formatProvider)}}");
+				}
 			}
 			else
 			{
-				format.Append($"{{{properties[i].Name}}}");
+				if (nullPlaceholder is not null && properties[i].IsNullable)
+				{
+					string escaped = GeneratorHelpers.EscapeString(nullPlaceholder);
+					format.Append($"{{{properties[i].Name}?.ToString() ?? \"{escaped}\"}}");
+				}
+				else
+				{
+					format.Append($"{{{properties[i].Name}}}");
+				}
 			}
 		}
 
@@ -345,5 +376,39 @@ public sealed class ToStringGenerator : IIncrementalGenerator
 		}
 
 		return CollectionFormat.Count;
+	}
+
+	private static string? GetNullPlaceholder(ClassDeclarationSyntax classDeclaration, SemanticModel semanticModel)
+	{
+		foreach (AttributeListSyntax attributeList in classDeclaration.AttributeLists)
+		{
+			foreach (AttributeSyntax attribute in attributeList.Attributes)
+			{
+				string name = attribute.Name.ToString();
+
+				if (name != AttributeNames.ShortName && name != AttributeNames.FullName)
+					continue;
+
+				if (attribute.ArgumentList is null)
+					return null;
+
+				foreach (AttributeArgumentSyntax arg in attribute.ArgumentList.Arguments)
+				{
+					if (arg.NameEquals?.Name.Identifier.Text != nameof(GenerateToStringAttribute.NullPlaceholder))
+						continue;
+
+					Optional<object?> value = semanticModel.GetConstantValue(arg.Expression);
+
+					if (value.HasValue && value.Value is string stringValue)
+						return stringValue;
+
+					break;
+				}
+
+				return null;
+			}
+		}
+
+		return null;
 	}
 }

--- a/tests/BB84.SourceGenerators.Tests/ToStringGeneratorTests.cs
+++ b/tests/BB84.SourceGenerators.Tests/ToStringGeneratorTests.cs
@@ -327,6 +327,142 @@ public sealed class ToStringGeneratorTests
 
 		Assert.IsInstanceOfType<IFormattable>(model);
 	}
+
+	[TestMethod]
+	public void ToStringShouldRenderNullPlaceholderForNullableReferenceType()
+	{
+		ToStringNullPlaceholderTestModel model = new()
+		{
+			Id = 1,
+			Name = null,
+			Score = 42
+		};
+
+		string? result = model.ToString();
+		string expected = nameof(ToStringNullPlaceholderTestModel) + " { " +
+			"Id = 1, " +
+			"Name = null, " +
+			"Score = 42 }";
+
+		Assert.AreEqual(expected, result);
+	}
+
+	[TestMethod]
+	public void ToStringShouldRenderNullPlaceholderForNullableValueType()
+	{
+		ToStringNullPlaceholderTestModel model = new()
+		{
+			Id = 1,
+			Name = "Test",
+			Score = null
+		};
+
+		string? result = model.ToString();
+		string expected = nameof(ToStringNullPlaceholderTestModel) + " { " +
+			"Id = 1, " +
+			"Name = Test, " +
+			"Score = null }";
+
+		Assert.AreEqual(expected, result);
+	}
+
+	[TestMethod]
+	public void ToStringShouldNotApplyNullPlaceholderForNonNullValues()
+	{
+		ToStringNullPlaceholderTestModel model = new()
+		{
+			Id = 7,
+			Name = "Jane",
+			Score = 99
+		};
+
+		string? result = model.ToString();
+		string expected = nameof(ToStringNullPlaceholderTestModel) + " { " +
+			"Id = 7, " +
+			"Name = Jane, " +
+			"Score = 99 }";
+
+		Assert.AreEqual(expected, result);
+	}
+
+	[TestMethod]
+	public void ToStringShouldRenderCustomNullPlaceholder()
+	{
+		ToStringCustomNullPlaceholderTestModel model = new()
+		{
+			Tag = null
+		};
+
+		string? result = model.ToString();
+		string expected = nameof(ToStringCustomNullPlaceholderTestModel) + " { " +
+			"Tag = <null> }";
+
+		Assert.AreEqual(expected, result);
+	}
+
+	[TestMethod]
+	public void ToStringShouldRenderNullPlaceholderWithFormatString()
+	{
+		ToStringNullPlaceholderFormatTestModel model = new()
+		{
+			CreatedAt = null
+		};
+
+		string? result = model.ToString();
+		string expected = nameof(ToStringNullPlaceholderFormatTestModel) + " { " +
+			"CreatedAt = null }";
+
+		Assert.AreEqual(expected, result);
+	}
+
+	[TestMethod]
+	public void ToStringShouldRenderFormattedValueWhenNullPlaceholderSetAndValueNotNull()
+	{
+		ToStringNullPlaceholderFormatTestModel model = new()
+		{
+			CreatedAt = new DateTime(2025, 3, 14)
+		};
+
+		string? result = model.ToString();
+		string expected = nameof(ToStringNullPlaceholderFormatTestModel) + " { " +
+			"CreatedAt = 2025-03-14 }";
+
+		Assert.AreEqual(expected, result);
+	}
+
+	[TestMethod]
+	public void ToStringFormattableShouldRenderNullPlaceholderForNullableProperty()
+	{
+		ToStringFormattableNullPlaceholderTestModel model = new()
+		{
+			Name = null,
+			Total = null
+		};
+
+		string? result = model.ToString();
+		string expected = nameof(ToStringFormattableNullPlaceholderTestModel) + " { " +
+			"Name = null, " +
+			"Total = null }";
+
+		Assert.AreEqual(expected, result);
+	}
+
+	[TestMethod]
+	public void ToStringFormattableShouldRenderNullPlaceholderWithFormatProvider()
+	{
+		ToStringFormattableNullPlaceholderTestModel model = new()
+		{
+			Name = null,
+			Total = null
+		};
+
+		string? result = ((IFormattable)model).ToString(null, CultureInfo.InvariantCulture);
+		string expected = nameof(ToStringFormattableNullPlaceholderTestModel) + " { " +
+			"Name = null, " +
+			"Total = null }";
+
+		Assert.AreEqual(expected, result);
+	}
 }
 
 [GenerateToString]
@@ -428,4 +564,32 @@ public partial class ToStringFormattableTestModel
 	public string? Name { get; set; }
 	public decimal Total { get; set; }
 	public DateTime CreatedAt { get; set; }
+}
+
+[GenerateToString(NullPlaceholder = "null")]
+public partial class ToStringNullPlaceholderTestModel
+{
+	public int Id { get; set; }
+	public string? Name { get; set; }
+	public int? Score { get; set; }
+}
+
+[GenerateToString(NullPlaceholder = "<null>")]
+public partial class ToStringCustomNullPlaceholderTestModel
+{
+	public string? Tag { get; set; }
+}
+
+[GenerateToString(NullPlaceholder = "null")]
+public partial class ToStringNullPlaceholderFormatTestModel
+{
+	[ToStringFormat("yyyy-MM-dd")]
+	public DateTime? CreatedAt { get; set; }
+}
+
+[GenerateToString(Formattable = true, NullPlaceholder = "null")]
+public partial class ToStringFormattableNullPlaceholderTestModel
+{
+	public string? Name { get; set; }
+	public decimal? Total { get; set; }
 }


### PR DESCRIPTION
**Changes:**

- Introduce `NullPlaceholder` property for custom null rendering in generated `ToString()`.
- Update generator logic to handle placeholders for nullable properties, including with format strings and `IFormattable`.
- `Add comprehensive tests and supporting models for all scenarios.
- Extend `README` with docs and examples.

closes #142 