### PR TITLE
feat(ToString): add `[ToStringOrder]` for explicit property ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -670,6 +670,7 @@ Generates a `ToString()` override for classes, returning a formatted string cont
 ```csharp
 [GenerateToString(params string[] excludeProperties)]
 [ToStringFormat(string format)]  // per-property
+[ToStringOrder(int order)]       // per-property
 ```
 
 **Parameters:**
@@ -683,6 +684,7 @@ Generates a `ToString()` override for classes, returning a formatted string cont
 **Per-Property Formatting:**
 
 - `[ToStringFormat("format")]` - Applied to individual properties to specify a custom format string. The format is passed to the property's `ToString(string)` method at runtime (e.g., `"yyyy-MM-dd"` for dates, `"C2"` for currency, `"F2"` for fixed-point).
+- `[ToStringOrder(n)]` - Controls the position of a property in the generated output. Properties with an explicit order appear first in ascending order, followed by unordered properties in their natural declaration order. Can be combined with `[ToStringFormat]` and works alongside `excludeProperties`.
 
 **Collection Format Modes:**
 
@@ -773,6 +775,19 @@ public partial class Person
     public string? Name { get; set; }
     public int? Age { get; set; }
 }
+
+// Explicit property ordering — ordered properties first, then unordered in declaration order
+[GenerateToString]
+public partial class Contact
+{
+    [ToStringOrder(2)]
+    public string? LastName { get; set; }
+
+    [ToStringOrder(1)]
+    public string? FirstName { get; set; }
+
+    public int Age { get; set; }
+}
 ```
 
 #### Generated Code
@@ -791,6 +806,7 @@ The generator creates a `ToString()` override on the partial class that:
 - For dictionary properties in `Elements` mode, emits a private generic helper `DictionaryToString<TKey, TValue>`
 - When `Formattable = true`, implements `IFormattable` with `ToString(string?, IFormatProvider?)` — properties whose types implement `IFormattable` receive the `formatProvider`; others use their default `ToString()`
 - When `NullPlaceholder` is set, nullable properties with a `null` value emit `Property?.ToString() ?? "placeholder"` instead of the raw interpolation slot; `[ToStringFormat]` is preserved as an explicit `.ToString("fmt")` call
+- When any property carries `[ToStringOrder(n)]`, properties are reordered: those with an explicit order appear first (ascending by value), followed by unordered properties in their original declaration order
 
 #### Usage Example
 
@@ -876,6 +892,10 @@ Console.WriteLine(person.ToString());
 var personWithValues = new Person { Id = 2, Name = "John", Age = 30 };
 Console.WriteLine(personWithValues.ToString());
 // Output: Person { Id = 2, Name = John, Age = 30 }
+
+var contact = new Contact { LastName = "Doe", FirstName = "John", Age = 30 };
+Console.WriteLine(contact.ToString());
+// Output: Contact { FirstName = John, LastName = Doe, Age = 30 }
 ```
 
 ### 7. Validator Generator

--- a/src/BB84.SourceGenerators/AttributeSourceGenerator.cs
+++ b/src/BB84.SourceGenerators/AttributeSourceGenerator.cs
@@ -81,6 +81,9 @@ public sealed class AttributeSourceGenerator : IIncrementalGenerator
 	private static readonly string ToStringFormatAttributeSource =
 		AttributeSourceRewriter.ReadAndTransform("ToStringFormatAttribute.cs");
 
+	private static readonly string ToStringOrderAttributeSource =
+		AttributeSourceRewriter.ReadAndTransform("ToStringOrderAttribute.cs");
+
 	private static readonly string GenerateValidatorAttributeSource =
 		AttributeSourceRewriter.ReadAndTransform("GenerateValidatorAttribute.cs");
 
@@ -117,6 +120,7 @@ public sealed class AttributeSourceGenerator : IIncrementalGenerator
 			ctx.AddSource("GenerateToStringAttribute.g.cs", GenerateToStringAttributeSource);
 			ctx.AddSource("GenerateValidatorAttribute.g.cs", GenerateValidatorAttributeSource);
 			ctx.AddSource("ToStringFormatAttribute.g.cs", ToStringFormatAttributeSource);
+			ctx.AddSource("ToStringOrderAttribute.g.cs", ToStringOrderAttributeSource);
 			ctx.AddSource("PropertyMappingAttribute.g.cs", PropertyMappingAttributeSource);
 		});
 	}

--- a/src/BB84.SourceGenerators/Attributes/ToStringOrderAttribute.cs
+++ b/src/BB84.SourceGenerators/Attributes/ToStringOrderAttribute.cs
@@ -1,0 +1,21 @@
+// Copyright: 2026 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+namespace BB84.SourceGenerators.Attributes;
+
+/// <summary>
+/// Specifies the sort position of a property in the generated <c>ToString()</c> output.
+/// Properties with an explicit order are rendered first in ascending order, followed by
+/// unordered properties in their natural declaration order.
+/// </summary>
+/// <param name="order">The sort position (lower values appear first).</param>
+[AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
+internal sealed class ToStringOrderAttribute(int order) : Attribute
+{
+	/// <summary>
+	/// Gets the sort position for this property in the generated <c>ToString()</c> output.
+	/// </summary>
+	public int Order { get; } = order;
+}

--- a/src/BB84.SourceGenerators/BB84.SourceGenerators.csproj
+++ b/src/BB84.SourceGenerators/BB84.SourceGenerators.csproj
@@ -53,6 +53,7 @@
 		<EmbeddedResource Include="Attributes\GenerateToStringAttribute.cs" LogicalName="GenerateToStringAttribute.cs" />
 		<EmbeddedResource Include="Attributes\GenerateValidatorAttribute.cs" LogicalName="GenerateValidatorAttribute.cs" />
 		<EmbeddedResource Include="Attributes\ToStringFormatAttribute.cs" LogicalName="ToStringFormatAttribute.cs" />
+		<EmbeddedResource Include="Attributes\ToStringOrderAttribute.cs" LogicalName="ToStringOrderAttribute.cs" />
 		<EmbeddedResource Include="Attributes\PropertyMappingAttribute.cs" LogicalName="PropertyMappingAttribute.cs" />
 	</ItemGroup>
 	<ItemGroup>

--- a/src/BB84.SourceGenerators/Helpers/GeneratorHelpers.cs
+++ b/src/BB84.SourceGenerators/Helpers/GeneratorHelpers.cs
@@ -261,6 +261,11 @@ internal static class GeneratorHelpers
 	/// When not <see langword="null"/>, checks whether the property is decorated with the specified attribute
 	/// and sets <see cref="PropertyDescriptor.FormatString"/> accordingly.
 	/// </param>
+	/// <param name="toStringOrderAttributeName">
+	/// When not <see langword="null"/>, checks whether the property is decorated with the specified attribute
+	/// and sets <see cref="PropertyDescriptor.Order"/> accordingly. Properties with an explicit order are
+	/// sorted first (ascending), followed by unordered properties in declaration order.
+	/// </param>
 	/// <returns>An immutable array of <see cref="PropertyDescriptor"/> instances.</returns>
 	internal static ImmutableArray<PropertyDescriptor> GetPropertyDescriptors(
 		INamedTypeSymbol classSymbol,
@@ -268,7 +273,8 @@ internal static class GeneratorHelpers
 		bool requireSetter = false,
 		string? cloneableAttributeName = null,
 		bool detectCollections = false,
-		string? toStringFormatAttributeName = null)
+		string? toStringFormatAttributeName = null,
+		string? toStringOrderAttributeName = null)
 	{
 		ImmutableArray<PropertyDescriptor>.Builder builder = ImmutableArray.CreateBuilder<PropertyDescriptor>();
 
@@ -292,6 +298,7 @@ internal static class GeneratorHelpers
 			string? dictionaryValueTypeName = null;
 			bool isDictionaryValueCloneable = false;
 			string? formatString = null;
+			int? order = null;
 
 			if (cloneableAttributeName is not null)
 			{
@@ -314,6 +321,20 @@ internal static class GeneratorHelpers
 						&& attributeData.ConstructorArguments[0].Value is string fmt)
 					{
 						formatString = fmt;
+						break;
+					}
+				}
+			}
+
+			if (toStringOrderAttributeName is not null)
+			{
+				foreach (AttributeData attributeData in propertySymbol.GetAttributes())
+				{
+					if (attributeData.AttributeClass?.ToDisplayString() == toStringOrderAttributeName
+						&& attributeData.ConstructorArguments.Length == 1
+						&& attributeData.ConstructorArguments[0].Value is int ord)
+					{
+						order = ord;
 						break;
 					}
 				}
@@ -348,10 +369,16 @@ internal static class GeneratorHelpers
 					DetectCollectionKind(propertySymbol.Type, cloneableAttributeName);
 			}
 
-			builder.Add(new PropertyDescriptor(propertySymbol.Name, typeName, isValueType, isNullable, isCloneable, collectionKind, elementTypeName, isElementCloneable, dictionaryValueTypeName, isDictionaryValueCloneable, formatString, isFormattable));
+			builder.Add(new PropertyDescriptor(propertySymbol.Name, typeName, isValueType, isNullable, isCloneable, collectionKind, elementTypeName, isElementCloneable, dictionaryValueTypeName, isDictionaryValueCloneable, formatString, isFormattable, order));
 		}
 
-		return builder.ToImmutable();
+		if (toStringOrderAttributeName is null)
+			return builder.ToImmutable();
+
+		// Ordered properties first (ascending), then unordered in declaration order (stable sort).
+		return [.. builder
+			.OrderBy(static p => p.Order.HasValue ? 0 : 1)
+			.ThenBy(static p => p.Order ?? int.MaxValue)];
 	}
 
 	/// <summary>

--- a/src/BB84.SourceGenerators/Models/PropertyDescriptor.cs
+++ b/src/BB84.SourceGenerators/Models/PropertyDescriptor.cs
@@ -9,7 +9,7 @@ namespace BB84.SourceGenerators.Models;
 /// Describes a property discovered during source generation, carrying metadata
 /// needed by multiple generators (Equality, Cloneable, Builder, ToString).
 /// </summary>
-internal sealed record PropertyDescriptor(string Name, string TypeName, bool IsValueType, bool IsNullable, bool IsCloneable, CollectionKind CollectionKind = CollectionKind.None, string? ElementTypeName = null, bool IsElementCloneable = false, string? DictionaryValueTypeName = null, bool IsDictionaryValueCloneable = false, string? FormatString = null, bool IsFormattable = false)
+internal sealed record PropertyDescriptor(string Name, string TypeName, bool IsValueType, bool IsNullable, bool IsCloneable, CollectionKind CollectionKind = CollectionKind.None, string? ElementTypeName = null, bool IsElementCloneable = false, string? DictionaryValueTypeName = null, bool IsDictionaryValueCloneable = false, string? FormatString = null, bool IsFormattable = false, int? Order = null)
 {
 	/// <summary>
 	/// Gets the name of the property.
@@ -79,4 +79,10 @@ internal sealed record PropertyDescriptor(string Name, string TypeName, bool IsV
 	/// Gets a value indicating whether the property type implements <see cref="System.IFormattable"/>.
 	/// </summary>
 	public bool IsFormattable { get; } = IsFormattable;
+
+	/// <summary>
+	/// Gets the explicit sort position for this property in the generated <c>ToString()</c> output,
+	/// or <see langword="null"/> if no order was specified.
+	/// </summary>
+	public int? Order { get; } = Order;
 }

--- a/src/BB84.SourceGenerators/ToStringGenerator.cs
+++ b/src/BB84.SourceGenerators/ToStringGenerator.cs
@@ -26,6 +26,7 @@ public sealed class ToStringGenerator : IIncrementalGenerator
 		GeneratorHelpers.GetAttributeNames<GenerateToStringAttribute>();
 
 	private static readonly string ToStringFormatAttributeName = typeof(ToStringFormatAttribute).FullName;
+	private static readonly string ToStringOrderAttributeName = typeof(ToStringOrderAttribute).FullName;
 
 	/// <inheritdoc/>
 	public void Initialize(IncrementalGeneratorInitializationContext context)
@@ -41,7 +42,7 @@ public sealed class ToStringGenerator : IIncrementalGenerator
 		bool formattable = GetFormattable(ctx.ClassDeclaration, ctx.SemanticModel);
 		string? nullPlaceholder = GetNullPlaceholder(ctx.ClassDeclaration, ctx.SemanticModel);
 		HashSet<string> excludedProperties = GeneratorHelpers.GetExcludedProperties(ctx.ClassDeclaration, ctx.SemanticModel, nameof(GenerateToStringAttribute));
-		ImmutableArray<PropertyDescriptor> properties = GeneratorHelpers.GetPropertyDescriptors(ctx.ClassSymbol, excludedProperties, detectCollections: true, toStringFormatAttributeName: ToStringFormatAttributeName);
+		ImmutableArray<PropertyDescriptor> properties = GeneratorHelpers.GetPropertyDescriptors(ctx.ClassSymbol, excludedProperties, detectCollections: true, toStringFormatAttributeName: ToStringFormatAttributeName, toStringOrderAttributeName: ToStringOrderAttributeName);
 
 		SourceBuilder sb = new();
 

--- a/tests/BB84.SourceGenerators.Tests/AttributeSourceGeneratorTests.cs
+++ b/tests/BB84.SourceGenerators.Tests/AttributeSourceGeneratorTests.cs
@@ -54,6 +54,7 @@ public sealed class AttributeSourceGeneratorAttributeCoverageTests
 			nameof(GenerateAutoMapperAttribute),
 			nameof(PropertyMappingAttribute),
 			nameof(ToStringFormatAttribute),
+			nameof(ToStringOrderAttribute)
 		];
 
 		Assert.HasCount(expectedAttributeClassNames.Length, GeneratedAttributeSources,

--- a/tests/BB84.SourceGenerators.Tests/ToStringGeneratorTests.cs
+++ b/tests/BB84.SourceGenerators.Tests/ToStringGeneratorTests.cs
@@ -431,6 +431,44 @@ public sealed class ToStringGeneratorTests
 	}
 
 	[TestMethod]
+	public void ToStringShouldRespectExplicitPropertyOrder()
+	{
+		ToStringOrderTestModel model = new()
+		{
+			LastName = "Doe",
+			FirstName = "John",
+			Age = 30
+		};
+
+		string? result = model.ToString();
+		string expected = $"{nameof(ToStringOrderTestModel)} {{ " +
+			$"FirstName = John, " +
+			$"LastName = Doe, " +
+			$"Age = 30 }}";
+
+		Assert.AreEqual(expected, result);
+	}
+
+	[TestMethod]
+	public void ToStringShouldPlaceUnorderedPropertiesAfterOrderedOnes()
+	{
+		ToStringPartialOrderTestModel model = new()
+		{
+			Z = "z",
+			A = "a",
+			Middle = "m"
+		};
+
+		string? result = model.ToString();
+		string expected = $"{nameof(ToStringPartialOrderTestModel)} {{ " +
+			$"A = a, " +
+			$"Z = z, " +
+			$"Middle = m }}";
+
+		Assert.AreEqual(expected, result);
+	}
+
+	[TestMethod]
 	public void ToStringFormattableShouldRenderNullPlaceholderForNullableProperty()
 	{
 		ToStringFormattableNullPlaceholderTestModel model = new()
@@ -592,4 +630,28 @@ public partial class ToStringFormattableNullPlaceholderTestModel
 {
 	public string? Name { get; set; }
 	public decimal? Total { get; set; }
+}
+
+[GenerateToString]
+public partial class ToStringOrderTestModel
+{
+	[ToStringOrder(2)]
+	public string? LastName { get; set; }
+
+	[ToStringOrder(1)]
+	public string? FirstName { get; set; }
+
+	public int Age { get; set; }
+}
+
+[GenerateToString]
+public partial class ToStringPartialOrderTestModel
+{
+	[ToStringOrder(2)]
+	public string? Z { get; set; }
+
+	[ToStringOrder(1)]
+	public string? A { get; set; }
+
+	public string? Middle { get; set; }
 }


### PR DESCRIPTION
**Changes:**

- Introduce `[ToStringOrder(int)]` attribute to control property order in generated `ToString()` methods.
- Registered and embedded the new attribute  and dded unit tests for ordering scenarios.
- Updated generator logic to support ordered and unordered properties, extended `PropertyDescriptor, and documented usage in `README`.

closes #143 