### PR TITLE
refactor(generators): refactor attribute extraction in generators

### DIFF
--- a/src/BB84.SourceGenerators/DisposableGenerator.cs
+++ b/src/BB84.SourceGenerators/DisposableGenerator.cs
@@ -37,7 +37,8 @@ public sealed class DisposableGenerator : IIncrementalGenerator
 		if (!GeneratorHelpers.TryCreateContext(input, out GeneratorContext ctx))
 			return;
 
-		(bool generateFinalizer, bool generateAsync) = GetAttributeOptions(ctx.ClassDeclaration);
+		bool generateFinalizer = GetGenerateFinalizer(ctx.ClassSymbol);
+		bool generateAsync = GetGenerateAsync(ctx.ClassSymbol);
 
 		// Check if IAsyncDisposable is available in the target framework
 		if (generateAsync)
@@ -97,55 +98,11 @@ public sealed class DisposableGenerator : IIncrementalGenerator
 		context.AddSource(hintName, sb.ToString());
 	}
 
-	private static (bool generateFinalizer, bool generateAsync) GetAttributeOptions(ClassDeclarationSyntax classDeclaration)
-	{
-		bool generateFinalizer = false;
-		bool generateAsync = false;
+	private static bool GetGenerateFinalizer(INamedTypeSymbol namedTypeSymbol)
+		=> GeneratorHelpers.GetConstructorArgumentValue(namedTypeSymbol, AttributeNames.FullName, 0, false);
 
-		foreach (AttributeListSyntax attributeList in classDeclaration.AttributeLists)
-		{
-			foreach (AttributeSyntax attribute in attributeList.Attributes)
-			{
-				string name = attribute.Name.ToString();
-
-				if (name != AttributeNames.ShortName && name != AttributeNames.FullName)
-					continue;
-
-				if (attribute.ArgumentList is null || attribute.ArgumentList.Arguments.Count == 0)
-					return (generateFinalizer, generateAsync);
-
-				foreach (AttributeArgumentSyntax argument in attribute.ArgumentList.Arguments)
-				{
-					string? paramName = argument.NameColon?.Name.Identifier.Text;
-					string argText = argument.Expression.ToString();
-
-					if (!bool.TryParse(argText, out bool value))
-						continue;
-
-					switch (paramName)
-					{
-						case "generateFinalizer":
-							generateFinalizer = value;
-							break;
-						case "async":
-							generateAsync = value;
-							break;
-						default:
-							int index = attribute.ArgumentList.Arguments.IndexOf(argument);
-							if (index == 0)
-								generateFinalizer = value;
-							else if (index == 1)
-								generateAsync = value;
-							break;
-					}
-				}
-
-				return (generateFinalizer, generateAsync);
-			}
-		}
-
-		return (generateFinalizer, generateAsync);
-	}
+	private static bool GetGenerateAsync(INamedTypeSymbol namedTypeSymbol)
+		=> GeneratorHelpers.GetConstructorArgumentValue(namedTypeSymbol, AttributeNames.FullName, 1, false);
 
 	private static ImmutableArray<(string FieldName, int Order, int SourceIndex)> GetDisposableFields(ClassDeclarationSyntax classDeclaration)
 	{

--- a/src/BB84.SourceGenerators/Helpers/GeneratorHelpers.cs
+++ b/src/BB84.SourceGenerators/Helpers/GeneratorHelpers.cs
@@ -84,19 +84,6 @@ internal static class GeneratorHelpers
 	}
 
 	/// <summary>
-	/// Gets the set of excluded property names from an attribute's constructor arguments.
-	/// </summary>
-	/// <param name="classDeclaration">The class declaration syntax.</param>
-	/// <param name="semanticModel">The semantic model.</param>
-	/// <param name="attributeFullName">The full name of the attribute (e.g., "GenerateToStringAttribute").</param>
-	/// <returns>A set of excluded property names.</returns>
-	internal static HashSet<string> GetExcludedProperties(
-		ClassDeclarationSyntax classDeclaration,
-		SemanticModel semanticModel,
-		string attributeFullName)
-		=> GetExcludedProperties((TypeDeclarationSyntax)classDeclaration, semanticModel, attributeFullName);
-
-	/// <summary>
 	/// Gets the set of excluded property names from an attribute's constructor arguments on a type declaration.
 	/// </summary>
 	/// <param name="typeDeclaration">The type declaration syntax (class or struct).</param>
@@ -147,6 +134,89 @@ internal static class GeneratorHelpers
 			: attributeName;
 
 	/// <summary>
+	/// Gets the value of a named argument from an attribute on a type declaration.
+	/// Searches the attribute lists for an attribute matching <paramref name="attributeShortName"/> or
+	/// <paramref name="attributeFullName"/>, then looks for a named argument with the given <paramref name="propertyName"/>.
+	/// </summary>
+	/// <typeparam name="T">The expected type of the argument value.</typeparam>
+	/// <param name="typeDeclaration">The type declaration syntax.</param>
+	/// <param name="semanticModel">The semantic model.</param>
+	/// <param name="attributeShortName">The short name of the attribute.</param>
+	/// <param name="attributeFullName">The full name of the attribute.</param>
+	/// <param name="propertyName">The name of the named argument to extract.</param>
+	/// <param name="defaultValue">The default value to return if the argument is not found.</param>
+	/// <returns>The extracted value, or <paramref name="defaultValue"/> if not found.</returns>
+	internal static T GetNamedArgumentValue<T>(
+		TypeDeclarationSyntax typeDeclaration,
+		SemanticModel semanticModel,
+		string attributeShortName,
+		string attributeFullName,
+		string propertyName,
+		T defaultValue)
+	{
+		foreach (AttributeListSyntax attributeList in typeDeclaration.AttributeLists)
+		{
+			foreach (AttributeSyntax attribute in attributeList.Attributes)
+			{
+				string name = attribute.Name.ToString();
+
+				if (name != attributeShortName && name != attributeFullName)
+					continue;
+
+				if (attribute.ArgumentList is null)
+					return defaultValue;
+
+				foreach (AttributeArgumentSyntax arg in attribute.ArgumentList.Arguments)
+				{
+					if (arg.NameEquals?.Name.Identifier.Text != propertyName)
+						continue;
+
+					Optional<object?> value = semanticModel.GetConstantValue(arg.Expression);
+
+					if (value.HasValue && value.Value is T typedValue)
+						return typedValue;
+
+					break;
+				}
+
+				return defaultValue;
+			}
+		}
+
+		return defaultValue;
+	}
+
+	/// <summary>
+	/// Gets the value of a positional constructor argument from an attribute on a type symbol.
+	/// Searches the attributes of <paramref name="typeSymbol"/> for one whose class name matches
+	/// <paramref name="attributeFullName"/>, then returns the constructor argument at <paramref name="index"/>.
+	/// </summary>
+	/// <typeparam name="T">The expected type of the constructor argument value.</typeparam>
+	/// <param name="typeSymbol">The type symbol to inspect.</param>
+	/// <param name="attributeFullName">The simple type name of the attribute (e.g., "GenerateIniFileAttribute").</param>
+	/// <param name="index">The zero-based index of the constructor argument.</param>
+	/// <param name="defaultValue">The default value to return if the argument is not found.</param>
+	/// <returns>The extracted value, or <paramref name="defaultValue"/> if not found.</returns>
+	internal static T GetConstructorArgumentValue<T>(
+		INamedTypeSymbol typeSymbol,
+		string attributeFullName,
+		int index,
+		T defaultValue)
+	{
+		foreach (AttributeData attributeData in typeSymbol.GetAttributes())
+		{
+			if (attributeData.AttributeClass?.Name != attributeFullName)
+				continue;
+
+			return attributeData.ConstructorArguments.Length > index && attributeData.ConstructorArguments[index].Value is T typedValue
+				? typedValue
+				: defaultValue;
+		}
+
+		return defaultValue;
+	}
+
+	/// <summary>
 	/// Returns the fully-qualified metadata name, the simple full name, and the short name
 	/// (without the "Attribute" suffix) for the given attribute type.
 	/// </summary>
@@ -185,7 +255,7 @@ internal static class GeneratorHelpers
 	/// <param name="context">The generator attribute syntax context.</param>
 	/// <returns>A tuple of class declaration syntax and semantic model, or null if the target node is not a class declaration.</returns>
 	internal static (ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)? TransformClassSyntax(GeneratorAttributeSyntaxContext context)
-		=> context.TargetNode is not ClassDeclarationSyntax classSyntax ? null : ((ClassDeclarationSyntax ClassSyntax, SemanticModel SemanticModel)?)(classSyntax, context.SemanticModel);
+		=> context.TargetNode is not ClassDeclarationSyntax classSyntax ? null : (classSyntax, context.SemanticModel);
 
 	/// <summary>
 	/// Registers a class-based incremental source generator pipeline that filters for classes

--- a/src/BB84.SourceGenerators/IniFileGenerator.cs
+++ b/src/BB84.SourceGenerators/IniFileGenerator.cs
@@ -39,9 +39,9 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 		if (!GeneratorHelpers.TryCreateContext(input, out GeneratorContext ctx))
 			return;
 
-		string stringComparison = GetStringComparison(ctx.ClassDeclaration, ctx.SemanticModel);
-		string sectionDelimiter = GetSectionDelimiter(ctx.ClassDeclaration, ctx.SemanticModel);
-		bool serializeComments = GetSerializeComments(ctx.ClassDeclaration);
+		string stringComparison = GetStringComparison(ctx.ClassSymbol).ToString();
+		string sectionDelimiter = GetSectionDelimiter(ctx.ClassSymbol);
+		bool serializeComments = GetSerializeComments(ctx.ClassDeclaration, ctx.SemanticModel);
 
 		List<SectionInfo> sections = GetSections(ctx.ClassDeclaration, ctx.SemanticModel, sectionDelimiter, serializeComments);
 
@@ -595,74 +595,14 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 			};
 	}
 
-	private static string GetStringComparison(ClassDeclarationSyntax classDeclaration, SemanticModel semanticModel)
-	{
-		INamedTypeSymbol? classSymbol = semanticModel.GetDeclaredSymbol(classDeclaration);
+	private static StringComparison GetStringComparison(INamedTypeSymbol classSymbol)
+		=> (StringComparison)GeneratorHelpers.GetConstructorArgumentValue(classSymbol, AttributeNames.FullName, 0, (int)StringComparison.OrdinalIgnoreCase);
 
-		if (classSymbol is null)
-			return nameof(StringComparison.OrdinalIgnoreCase);
+	private static string GetSectionDelimiter(INamedTypeSymbol classSymbol)
+		=> GeneratorHelpers.GetConstructorArgumentValue(classSymbol, AttributeNames.FullName, 1, ".");
 
-		AttributeData? attributeData = FindGeneratorAttribute(classSymbol);
-
-		return attributeData is not null
-			&& attributeData.ConstructorArguments.Length > 0
-			&& attributeData.ConstructorArguments[0].Value is int comparisonValue
-				? comparisonValue switch
-				{
-					0 => nameof(StringComparison.CurrentCulture),
-					1 => nameof(StringComparison.CurrentCultureIgnoreCase),
-					2 => nameof(StringComparison.InvariantCulture),
-					3 => nameof(StringComparison.InvariantCultureIgnoreCase),
-					4 => nameof(StringComparison.Ordinal),
-					5 => nameof(StringComparison.OrdinalIgnoreCase),
-					_ => nameof(StringComparison.OrdinalIgnoreCase)
-				}
-				: nameof(StringComparison.OrdinalIgnoreCase);
-	}
-
-	private static string GetSectionDelimiter(ClassDeclarationSyntax classDeclaration, SemanticModel semanticModel)
-	{
-		INamedTypeSymbol? classSymbol = semanticModel.GetDeclaredSymbol(classDeclaration);
-		if (classSymbol is null)
-			return ".";
-
-		AttributeData? attributeData = FindGeneratorAttribute(classSymbol);
-
-		return attributeData is not null
-			&& attributeData.ConstructorArguments.Length > 1
-			&& attributeData.ConstructorArguments[1].Value is string delimiterValue
-				? delimiterValue
-				: ".";
-	}
-
-	private static bool GetSerializeComments(ClassDeclarationSyntax classDeclaration)
-	{
-		foreach (AttributeListSyntax attributeList in classDeclaration.AttributeLists)
-		{
-			foreach (AttributeSyntax attribute in attributeList.Attributes)
-			{
-				string name = attribute.Name.ToString();
-
-				if (name != AttributeNames.ShortName && name != AttributeNames.FullName)
-					continue;
-
-				if (attribute.ArgumentList is null)
-					continue;
-
-				foreach (AttributeArgumentSyntax argument in attribute.ArgumentList.Arguments)
-				{
-					if (argument.NameEquals?.Name.Identifier.Text == "SerializeComments")
-					{
-						string expressionText = argument.Expression.ToString();
-						if (expressionText == "true")
-							return true;
-					}
-				}
-			}
-		}
-
-		return false;
-	}
+	private static bool GetSerializeComments(ClassDeclarationSyntax classDeclaration, SemanticModel semanticModel)
+		=> GeneratorHelpers.GetNamedArgumentValue(classDeclaration, semanticModel, AttributeNames.ShortName, AttributeNames.FullName, nameof(GenerateIniFileAttribute.SerializeComments), false);
 
 	private static string? GetXmlSummaryComment(ISymbol symbol)
 	{
@@ -810,17 +750,6 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 			typeName = typeName[..^1];
 
 		return typeName;
-	}
-
-	private static AttributeData? FindGeneratorAttribute(INamedTypeSymbol classSymbol)
-	{
-		foreach (AttributeData attr in classSymbol.GetAttributes())
-		{
-			if (attr.AttributeClass?.ToDisplayString() == AttributeNames.MetadataName)
-				return attr;
-		}
-
-		return null;
 	}
 
 	private sealed record SectionInfo(

--- a/src/BB84.SourceGenerators/NotificationsGenerator.cs
+++ b/src/BB84.SourceGenerators/NotificationsGenerator.cs
@@ -32,7 +32,9 @@ public sealed class NotificationsGenerator : IIncrementalGenerator
 		if (!GeneratorHelpers.TryCreateContext(input, out GeneratorContext ctx))
 			return;
 
-		(bool generatePropertyChanged, bool generatePropertyChanging, bool generateHasChanged) = GetAttributeOptions(ctx.ClassDeclaration);
+		bool generatePropertyChanged = GetPropertyChanged(ctx.ClassSymbol);
+		bool generatePropertyChanging = GetPropertyChanging(ctx.ClassSymbol);
+		bool generateHasChanged = GetHasChanged(ctx.ClassSymbol);
 
 		if (!generatePropertyChanged && !generatePropertyChanging)
 			return;
@@ -69,62 +71,14 @@ public sealed class NotificationsGenerator : IIncrementalGenerator
 		context.AddSource(hintName, sb.ToString());
 	}
 
-	private static (bool propertyChanged, bool propertyChanging, bool hasChanged) GetAttributeOptions(ClassDeclarationSyntax classDeclaration)
-	{
-		bool propertyChanged = true;
-		bool propertyChanging = true;
-		bool hasChanged = false;
+	private static bool GetPropertyChanged(INamedTypeSymbol namedTypeSymbol)
+		=> GeneratorHelpers.GetConstructorArgumentValue(namedTypeSymbol, AttributeNames.FullName, 0, true);
 
-		foreach (AttributeListSyntax attributeList in classDeclaration.AttributeLists)
-		{
-			foreach (AttributeSyntax attribute in attributeList.Attributes)
-			{
-				string name = attribute.Name.ToString();
+	private static bool GetPropertyChanging(INamedTypeSymbol namedTypeSymbol)
+		=> GeneratorHelpers.GetConstructorArgumentValue(namedTypeSymbol, AttributeNames.FullName, 1, true);
 
-				if (name != AttributeNames.ShortName && name != AttributeNames.FullName)
-					continue;
-
-				if (attribute.ArgumentList is null || attribute.ArgumentList.Arguments.Count == 0)
-					return (propertyChanged, propertyChanging, hasChanged);
-
-				foreach (AttributeArgumentSyntax argument in attribute.ArgumentList.Arguments)
-				{
-					string? paramName = argument.NameColon?.Name.Identifier.Text;
-					string argText = argument.Expression.ToString();
-
-					if (!bool.TryParse(argText, out bool value))
-						continue;
-
-					switch (paramName)
-					{
-						case "propertyChanged":
-							propertyChanged = value;
-							break;
-						case "propertyChanging":
-							propertyChanging = value;
-							break;
-						case "hasChanged":
-							hasChanged = value;
-							break;
-						default:
-							// Positional: first=propertyChanged, second=propertyChanging, third=hasChanged
-							int index = attribute.ArgumentList.Arguments.IndexOf(argument);
-							if (index == 0)
-								propertyChanged = value;
-							else if (index == 1)
-								propertyChanging = value;
-							else if (index == 2)
-								hasChanged = value;
-							break;
-					}
-				}
-
-				return (propertyChanged, propertyChanging, hasChanged);
-			}
-		}
-
-		return (propertyChanged, propertyChanging, hasChanged);
-	}
+	private static bool GetHasChanged(INamedTypeSymbol namedTypeSymbol)
+		=> GeneratorHelpers.GetConstructorArgumentValue(namedTypeSymbol, AttributeNames.FullName, 2, false);
 
 	private static void AppendClassStart(SourceBuilder sb, string className, string accessibility, bool propertyChanged, bool propertyChanging, bool hasChanged)
 	{

--- a/src/BB84.SourceGenerators/SingletonGenerator.cs
+++ b/src/BB84.SourceGenerators/SingletonGenerator.cs
@@ -58,7 +58,7 @@ public sealed class SingletonGenerator : IIncrementalGenerator
 			}
 		}
 
-		bool useLazy = GetUseLazy(ctx.ClassDeclaration);
+		bool useLazy = GetUseLazy(ctx.ClassSymbol);
 		string instanceTypeName = GetFirstInterfaceName(ctx.ClassSymbol) ?? ctx.ClassName;
 
 		SourceBuilder sb = new();
@@ -113,31 +113,9 @@ public sealed class SingletonGenerator : IIncrementalGenerator
 		sb.CloseClass();
 	}
 
-	private static bool GetUseLazy(ClassDeclarationSyntax classDeclaration)
-	{
-		foreach (AttributeListSyntax attributeList in classDeclaration.AttributeLists)
-		{
-			foreach (AttributeSyntax attribute in attributeList.Attributes)
-			{
-				string name = attribute.Name.ToString();
-
-				if (name != AttributeNames.ShortName && name != AttributeNames.FullName)
-					continue;
-
-				if (attribute.ArgumentList is null || attribute.ArgumentList.Arguments.Count == 0)
-					return true;
-
-				AttributeArgumentSyntax firstArg = attribute.ArgumentList.Arguments[0];
-				string argText = firstArg.Expression.ToString();
-
-				if (bool.TryParse(argText, out bool result))
-					return result;
-			}
-		}
-
-		return true;
-	}
-
+	private static bool GetUseLazy(INamedTypeSymbol namedTypeSymbol)
+		=> GeneratorHelpers.GetConstructorArgumentValue(namedTypeSymbol, AttributeNames.FullName, 0, true);
+	
 	private static string? GetFirstInterfaceName(INamedTypeSymbol classSymbol)
 		=> classSymbol.Interfaces.FirstOrDefault()?.Name;
 }

--- a/src/BB84.SourceGenerators/ToStringGenerator.cs
+++ b/src/BB84.SourceGenerators/ToStringGenerator.cs
@@ -227,138 +227,14 @@ public sealed class ToStringGenerator : IIncrementalGenerator
 	}
 
 	private static bool GetFormattable(ClassDeclarationSyntax classDeclaration, SemanticModel semanticModel)
-	{
-		foreach (AttributeListSyntax attributeList in classDeclaration.AttributeLists)
-		{
-			foreach (AttributeSyntax attribute in attributeList.Attributes)
-			{
-				string name = attribute.Name.ToString();
-
-				if (name != AttributeNames.ShortName && name != AttributeNames.FullName)
-					continue;
-
-				if (attribute.ArgumentList is null)
-					return false;
-
-				foreach (AttributeArgumentSyntax arg in attribute.ArgumentList.Arguments)
-				{
-					if (arg.NameEquals?.Name.Identifier.Text != nameof(GenerateToStringAttribute.Formattable))
-						continue;
-
-					Optional<object?> value = semanticModel.GetConstantValue(arg.Expression);
-
-					if (value.HasValue && value.Value is bool boolValue)
-						return boolValue;
-
-					break;
-				}
-
-				return false;
-			}
-		}
-
-		return false;
-	}
+		=> GeneratorHelpers.GetNamedArgumentValue(classDeclaration, semanticModel, AttributeNames.ShortName, AttributeNames.FullName, nameof(GenerateToStringAttribute.Formattable), false);
 
 	private static string GetSeparator(ClassDeclarationSyntax classDeclaration, SemanticModel semanticModel)
-	{
-		foreach (AttributeListSyntax attributeList in classDeclaration.AttributeLists)
-		{
-			foreach (AttributeSyntax attribute in attributeList.Attributes)
-			{
-				string name = attribute.Name.ToString();
-
-				if (name != AttributeNames.ShortName && name != AttributeNames.FullName)
-					continue;
-
-				if (attribute.ArgumentList is null)
-					return ", ";
-
-				foreach (AttributeArgumentSyntax arg in attribute.ArgumentList.Arguments)
-				{
-					if (arg.NameEquals?.Name.Identifier.Text != nameof(GenerateToStringAttribute.Separator))
-						continue;
-
-					Optional<object?> value = semanticModel.GetConstantValue(arg.Expression);
-
-					if (value.HasValue && value.Value is string stringValue)
-						return stringValue;
-
-					break;
-				}
-
-				return ", ";
-			}
-		}
-
-		return ", ";
-	}
+		=> GeneratorHelpers.GetNamedArgumentValue(classDeclaration, semanticModel, AttributeNames.ShortName, AttributeNames.FullName, nameof(GenerateToStringAttribute.Separator), ", ");
 
 	private static CollectionFormat GetCollectionFormat(ClassDeclarationSyntax classDeclaration, SemanticModel semanticModel)
-	{
-		foreach (AttributeListSyntax attributeList in classDeclaration.AttributeLists)
-		{
-			foreach (AttributeSyntax attribute in attributeList.Attributes)
-			{
-				string name = attribute.Name.ToString();
-
-				if (name != AttributeNames.ShortName && name != AttributeNames.FullName)
-					continue;
-
-				if (attribute.ArgumentList is null)
-					return CollectionFormat.Count;
-
-				foreach (AttributeArgumentSyntax arg in attribute.ArgumentList.Arguments)
-				{
-					if (arg.NameEquals?.Name.Identifier.Text != nameof(GenerateToStringAttribute.CollectionFormat))
-						continue;
-
-					Optional<object?> value = semanticModel.GetConstantValue(arg.Expression);
-
-					if (value.HasValue && value.Value is int intValue)
-						return (CollectionFormat)intValue;
-
-					break;
-				}
-
-				return CollectionFormat.Count;
-			}
-		}
-
-		return CollectionFormat.Count;
-	}
+		=> (CollectionFormat)GeneratorHelpers.GetNamedArgumentValue(classDeclaration, semanticModel, AttributeNames.ShortName, AttributeNames.FullName, nameof(GenerateToStringAttribute.CollectionFormat), (int)CollectionFormat.Count);
 
 	private static string? GetNullPlaceholder(ClassDeclarationSyntax classDeclaration, SemanticModel semanticModel)
-	{
-		foreach (AttributeListSyntax attributeList in classDeclaration.AttributeLists)
-		{
-			foreach (AttributeSyntax attribute in attributeList.Attributes)
-			{
-				string name = attribute.Name.ToString();
-
-				if (name != AttributeNames.ShortName && name != AttributeNames.FullName)
-					continue;
-
-				if (attribute.ArgumentList is null)
-					return null;
-
-				foreach (AttributeArgumentSyntax arg in attribute.ArgumentList.Arguments)
-				{
-					if (arg.NameEquals?.Name.Identifier.Text != nameof(GenerateToStringAttribute.NullPlaceholder))
-						continue;
-
-					Optional<object?> value = semanticModel.GetConstantValue(arg.Expression);
-
-					if (value.HasValue && value.Value is string stringValue)
-						return stringValue;
-
-					break;
-				}
-
-				return null;
-			}
-		}
-
-		return null;
-	}
+		=> GeneratorHelpers.GetNamedArgumentValue<string?>(classDeclaration, semanticModel, AttributeNames.ShortName, AttributeNames.FullName, nameof(GenerateToStringAttribute.NullPlaceholder), null);
 }


### PR DESCRIPTION
**Changes:**

- Refactored all generators to use new helper methods in `GeneratorHelpers` for extracting attribute arguments.
- Replaced manual parsing with `GetNamedArgumentValue` and `GetConstructorArgumentValue`.
- Updated method signatures to use `INamedTypeSymbol` where needed and removed redundant code.

closes #154 