### PR TITLE
feat(ToString): add `IncludeInherited` option to `GenerateToStringAttribute`

### DIFF
--- a/README.md
+++ b/README.md
@@ -680,6 +680,7 @@ Generates a `ToString()` override for classes, returning a formatted string cont
 - `Separator` - Custom separator string between properties (named argument, default: `", "`)
 - `Formattable` - When `true`, generates an `IFormattable` implementation so the class participates in composite formatting with custom `IFormatProvider` support (named argument, default: `false`)
 - `NullPlaceholder` - When set, nullable properties with a `null` value render this string instead of an empty string (named argument, default: `null` — empty string behavior). Common values: `"null"`, `"<null>"`
+- `IncludeInherited` - When `true`, public properties from base classes (up to but not including `object`) are also included in the output after the declared properties. The `excludeProperties` list applies to inherited members as well (named argument, default: `false`)
 
 **Per-Property Formatting:**
 
@@ -788,6 +789,20 @@ public partial class Contact
 
     public int Age { get; set; }
 }
+
+// Include inherited properties from base classes
+public class EntityBase
+{
+    public int Id { get; set; }
+    public string? CreatedBy { get; set; }
+}
+
+[GenerateToString(IncludeInherited = true)]
+public partial class Order : EntityBase
+{
+    public decimal Total { get; set; }
+    public string? Reference { get; set; }
+}
 ```
 
 #### Generated Code
@@ -807,6 +822,7 @@ The generator creates a `ToString()` override on the partial class that:
 - When `Formattable = true`, implements `IFormattable` with `ToString(string?, IFormatProvider?)` — properties whose types implement `IFormattable` receive the `formatProvider`; others use their default `ToString()`
 - When `NullPlaceholder` is set, nullable properties with a `null` value emit `Property?.ToString() ?? "placeholder"` instead of the raw interpolation slot; `[ToStringFormat]` is preserved as an explicit `.ToString("fmt")` call
 - When any property carries `[ToStringOrder(n)]`, properties are reordered: those with an explicit order appear first (ascending by value), followed by unordered properties in their original declaration order
+- When `IncludeInherited = true`, public readable properties from all base classes (up to but not including `object`) are appended after the declared properties; `excludeProperties` applies to inherited members as well
 
 #### Usage Example
 

--- a/src/BB84.SourceGenerators/Attributes/GenerateToStringAttribute.cs
+++ b/src/BB84.SourceGenerators/Attributes/GenerateToStringAttribute.cs
@@ -73,4 +73,13 @@ internal sealed class GenerateToStringAttribute(params string[] excludePropertie
 	/// Common values: <c>"null"</c>, <c>"&lt;null&gt;"</c>.
 	/// </summary>
 	public string? NullPlaceholder { get; set; }
+
+	/// <summary>
+	/// Gets or sets a value indicating whether to include inherited public properties from base classes
+	/// in the generated <c>ToString()</c> output.
+	/// When <see langword="true"/>, the generator walks the base type hierarchy and appends inherited properties
+	/// after the declared properties. The <c>excludeProperties</c> list applies to inherited members as well.
+	/// Defaults to <see langword="false"/>.
+	/// </summary>
+	public bool IncludeInherited { get; set; }
 }

--- a/src/BB84.SourceGenerators/Helpers/GeneratorHelpers.cs
+++ b/src/BB84.SourceGenerators/Helpers/GeneratorHelpers.cs
@@ -336,6 +336,10 @@ internal static class GeneratorHelpers
 	/// and sets <see cref="PropertyDescriptor.Order"/> accordingly. Properties with an explicit order are
 	/// sorted first (ascending), followed by unordered properties in declaration order.
 	/// </param>
+	/// <param name="includeInherited">
+	/// When <see langword="true"/>, also includes public properties from base types (excluding <see cref="object"/>).
+	/// The <paramref name="excludedProperties"/> set applies to inherited members as well.
+	/// </param>
 	/// <returns>An immutable array of <see cref="PropertyDescriptor"/> instances.</returns>
 	internal static ImmutableArray<PropertyDescriptor> GetPropertyDescriptors(
 		INamedTypeSymbol classSymbol,
@@ -344,11 +348,12 @@ internal static class GeneratorHelpers
 		string? cloneableAttributeName = null,
 		bool detectCollections = false,
 		string? toStringFormatAttributeName = null,
-		string? toStringOrderAttributeName = null)
+		string? toStringOrderAttributeName = null,
+		bool includeInherited = false)
 	{
 		ImmutableArray<PropertyDescriptor>.Builder builder = ImmutableArray.CreateBuilder<PropertyDescriptor>();
 
-		foreach (IPropertySymbol propertySymbol in GetPublicPropertySymbols(classSymbol, requireGetter: true, requireSetter: requireSetter))
+		foreach (IPropertySymbol propertySymbol in GetPublicPropertySymbols(classSymbol, includeInherited: includeInherited, requireGetter: true, requireSetter: requireSetter))
 		{
 			if (propertySymbol.IsWriteOnly)
 				continue;

--- a/src/BB84.SourceGenerators/ToStringGenerator.cs
+++ b/src/BB84.SourceGenerators/ToStringGenerator.cs
@@ -40,8 +40,9 @@ public sealed class ToStringGenerator : IIncrementalGenerator
 		string separator = GetSeparator(ctx.ClassDeclaration, ctx.SemanticModel);
 		bool formattable = GetFormattable(ctx.ClassDeclaration, ctx.SemanticModel);
 		string? nullPlaceholder = GetNullPlaceholder(ctx.ClassDeclaration, ctx.SemanticModel);
+		bool includeInherited = GetIncludeInherited(ctx.ClassDeclaration, ctx.SemanticModel);
 		HashSet<string> excludedProperties = GeneratorHelpers.GetExcludedProperties(ctx.ClassDeclaration, ctx.SemanticModel, nameof(GenerateToStringAttribute));
-		ImmutableArray<PropertyDescriptor> properties = GeneratorHelpers.GetPropertyDescriptors(ctx.ClassSymbol, excludedProperties, detectCollections: true, toStringFormatAttributeName: ToStringFormatAttributeName, toStringOrderAttributeName: ToStringOrderAttributeName);
+		ImmutableArray<PropertyDescriptor> properties = GeneratorHelpers.GetPropertyDescriptors(ctx.ClassSymbol, excludedProperties, detectCollections: true, toStringFormatAttributeName: ToStringFormatAttributeName, toStringOrderAttributeName: ToStringOrderAttributeName, includeInherited: includeInherited);
 
 		SourceBuilder sb = new();
 
@@ -237,4 +238,7 @@ public sealed class ToStringGenerator : IIncrementalGenerator
 
 	private static string? GetNullPlaceholder(ClassDeclarationSyntax classDeclaration, SemanticModel semanticModel)
 		=> GeneratorHelpers.GetNamedArgumentValue<string?>(classDeclaration, semanticModel, AttributeNames.ShortName, AttributeNames.FullName, nameof(GenerateToStringAttribute.NullPlaceholder), null);
+
+	private static bool GetIncludeInherited(ClassDeclarationSyntax classDeclaration, SemanticModel semanticModel)
+		=> GeneratorHelpers.GetNamedArgumentValue(classDeclaration, semanticModel, AttributeNames.ShortName, AttributeNames.FullName, nameof(GenerateToStringAttribute.IncludeInherited), false);
 }

--- a/tests/BB84.SourceGenerators.Tests/ToStringGeneratorTests.cs
+++ b/tests/BB84.SourceGenerators.Tests/ToStringGeneratorTests.cs
@@ -469,6 +469,60 @@ public sealed class ToStringGeneratorTests
 	}
 
 	[TestMethod]
+	public void ToStringShouldIncludeInheritedPropertiesWhenEnabled()
+	{
+		ToStringInheritedTestModel model = new()
+		{
+			Id = 7,
+			Name = "Base",
+			Extra = "Derived"
+		};
+
+		string? result = model.ToString();
+		string expected = $"{nameof(ToStringInheritedTestModel)} {{ " +
+			$"{nameof(model.Extra)} = {model.Extra}, " +
+			$"{nameof(model.Id)} = {model.Id}, " +
+			$"{nameof(model.Name)} = {model.Name} }}";
+
+		Assert.AreEqual(expected, result);
+	}
+
+	[TestMethod]
+	public void ToStringShouldNotIncludeInheritedPropertiesByDefault()
+	{
+		ToStringNoInheritTestModel model = new()
+		{
+			Id = 3,
+			Name = "Base",
+			Extra = "Derived"
+		};
+
+		string? result = model.ToString();
+		string expected = $"{nameof(ToStringNoInheritTestModel)} {{ " +
+			$"{nameof(model.Extra)} = {model.Extra} }}";
+
+		Assert.AreEqual(expected, result);
+	}
+
+	[TestMethod]
+	public void ToStringShouldRespectExcludedPropertiesForInheritedMembers()
+	{
+		ToStringInheritedExcludeTestModel model = new()
+		{
+			Id = 5,
+			Name = "Base",
+			Extra = "Derived"
+		};
+
+		string? result = model.ToString();
+		string expected = $"{nameof(ToStringInheritedExcludeTestModel)} {{ " +
+			$"{nameof(model.Extra)} = {model.Extra}, " +
+			$"{nameof(model.Id)} = {model.Id} }}";
+
+		Assert.AreEqual(expected, result);
+	}
+
+	[TestMethod]
 	public void ToStringFormattableShouldRenderNullPlaceholderForNullableProperty()
 	{
 		ToStringFormattableNullPlaceholderTestModel model = new()
@@ -654,4 +708,28 @@ public partial class ToStringPartialOrderTestModel
 	public string? A { get; set; }
 
 	public string? Middle { get; set; }
+}
+
+public class ToStringBaseModel
+{
+	public int Id { get; set; }
+	public string? Name { get; set; }
+}
+
+[GenerateToString(IncludeInherited = true)]
+public partial class ToStringInheritedTestModel : ToStringBaseModel
+{
+	public string? Extra { get; set; }
+}
+
+[GenerateToString]
+public partial class ToStringNoInheritTestModel : ToStringBaseModel
+{
+	public string? Extra { get; set; }
+}
+
+[GenerateToString("Name", IncludeInherited = true)]
+public partial class ToStringInheritedExcludeTestModel : ToStringBaseModel
+{
+	public string? Extra { get; set; }
 }


### PR DESCRIPTION
**Changes:**

- Enable inclusion of inherited properties in generated `ToString()`.
- Add tests for inherited property handling and exclusion and added supporting test models.
- Update `README.md` with usage and behavior details.

closes #141 