### PR TITLE
feat(validator): add `AllowedValues`/`DeniedValues` support to validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -937,6 +937,8 @@ Generates a `Validate()` method for classes, scanning properties for data annota
 - `[Phone]` - Validates that a string is a valid phone number format
 - `[CreditCard]` - Validates that a string passes the Luhn algorithm (credit card check)
 - `[Compare("OtherProperty")]` - Validates that the property value matches another property's value
+- `[AllowedValues(v1, v2, ...)]` (.NET 8+) - Emits an inline membership check; fails if the property value is not one of the listed values
+- `[DeniedValues(v1, v2, ...)]` (.NET 8+) - Emits an inline exclusion check; fails if the property value equals any of the listed values
 - **Custom `ValidationAttribute` subclasses** - Any attribute inheriting from `ValidationAttribute` is automatically detected and validated via `IsValid()` delegation
 
 **IValidatableObject Integration:**
@@ -1098,6 +1100,19 @@ public partial class DateRangeModel : IValidatableObject
         if (End <= Start)
             yield return new ValidationResult("End must be after Start.", new[] { nameof(End) });
     }
+}
+
+// AllowedValues / DeniedValues (.NET 8+) — inline membership/exclusion checks
+[GenerateValidator]
+public partial class OrderModel
+{
+    // Emits: if (!Equals(Status, "pending") && !Equals(Status, "shipped") && !Equals(Status, "delivered"))
+    [AllowedValues("pending", "shipped", "delivered", ErrorMessage = "Invalid order status.")]
+    public string? Status { get; set; }
+
+    // Emits: if (Equals(Priority, 0) || Equals(Priority, -1))
+    [DeniedValues(0, -1, ErrorMessage = "Priority must be positive.")]
+    public int Priority { get; set; }
 }
 ```
 

--- a/src/BB84.SourceGenerators/Attributes/GenerateValidatorAttribute.cs
+++ b/src/BB84.SourceGenerators/Attributes/GenerateValidatorAttribute.cs
@@ -12,17 +12,19 @@ namespace BB84.SourceGenerators.Attributes;
 /// <para>
 /// Supported data annotation attributes:
 /// <list type="bullet">
-/// <item><c>RequiredAttribute</c></item>
-/// <item><c>RangeAttribute</c></item>
-/// <item><c>StringLengthAttribute</c></item>
-/// <item><c>MinLengthAttribute</c></item>
-/// <item><c>MaxLengthAttribute</c></item>
-/// <item><c>RegularExpressionAttribute</c></item>
-/// <item><c>EmailAddressAttribute</c></item>
-/// <item><c>UrlAttribute</c></item>
-/// <item><c>PhoneAttribute</c></item>
-/// <item><c>CreditCardAttribute</c></item>
+/// <item><c>AllowedValuesAttribute</c> (.NET 8+) — emits inline membership check</item>
 /// <item><c>CompareAttribute</c></item>
+/// <item><c>CreditCardAttribute</c></item>
+/// <item><c>DeniedValuesAttribute</c> (.NET 8+) — emits inline exclusion check</item>
+/// <item><c>EmailAddressAttribute</c></item>
+/// <item><c>MaxLengthAttribute</c></item>
+/// <item><c>MinLengthAttribute</c></item>
+/// <item><c>PhoneAttribute</c></item>
+/// <item><c>RangeAttribute</c></item>
+/// <item><c>RegularExpressionAttribute</c></item>
+/// <item><c>RequiredAttribute</c></item>
+/// <item><c>StringLengthAttribute</c></item>
+/// <item><c>UrlAttribute</c></item>
 /// <item>Any custom <c>ValidationAttribute</c> subclass (via <c>IsValid</c> call)</item>
 /// </list>
 /// </para>

--- a/src/BB84.SourceGenerators/Helpers/DataAnnotationNames.cs
+++ b/src/BB84.SourceGenerators/Helpers/DataAnnotationNames.cs
@@ -10,17 +10,19 @@ namespace BB84.SourceGenerators.Helpers;
 /// </summary>
 internal static class DataAnnotationNames
 {
-	internal const string Required = "System.ComponentModel.DataAnnotations.RequiredAttribute";
-	internal const string Range = "System.ComponentModel.DataAnnotations.RangeAttribute";
-	internal const string StringLength = "System.ComponentModel.DataAnnotations.StringLengthAttribute";
-	internal const string MinLength = "System.ComponentModel.DataAnnotations.MinLengthAttribute";
-	internal const string MaxLength = "System.ComponentModel.DataAnnotations.MaxLengthAttribute";
-	internal const string RegularExpression = "System.ComponentModel.DataAnnotations.RegularExpressionAttribute";
-	internal const string EmailAddress = "System.ComponentModel.DataAnnotations.EmailAddressAttribute";
-	internal const string Url = "System.ComponentModel.DataAnnotations.UrlAttribute";
-	internal const string Phone = "System.ComponentModel.DataAnnotations.PhoneAttribute";
-	internal const string CreditCard = "System.ComponentModel.DataAnnotations.CreditCardAttribute";
+	internal const string AllowedValues = "System.ComponentModel.DataAnnotations.AllowedValuesAttribute";
 	internal const string Compare = "System.ComponentModel.DataAnnotations.CompareAttribute";
-	internal const string ValidationAttribute = "System.ComponentModel.DataAnnotations.ValidationAttribute";
+	internal const string CreditCard = "System.ComponentModel.DataAnnotations.CreditCardAttribute";
+	internal const string DeniedValues = "System.ComponentModel.DataAnnotations.DeniedValuesAttribute";
+	internal const string EmailAddress = "System.ComponentModel.DataAnnotations.EmailAddressAttribute";
 	internal const string IValidatableObject = "System.ComponentModel.DataAnnotations.IValidatableObject";
+	internal const string MaxLength = "System.ComponentModel.DataAnnotations.MaxLengthAttribute";
+	internal const string MinLength = "System.ComponentModel.DataAnnotations.MinLengthAttribute";
+	internal const string Phone = "System.ComponentModel.DataAnnotations.PhoneAttribute";
+	internal const string Range = "System.ComponentModel.DataAnnotations.RangeAttribute";
+	internal const string RegularExpression = "System.ComponentModel.DataAnnotations.RegularExpressionAttribute";
+	internal const string Required = "System.ComponentModel.DataAnnotations.RequiredAttribute";
+	internal const string StringLength = "System.ComponentModel.DataAnnotations.StringLengthAttribute";
+	internal const string Url = "System.ComponentModel.DataAnnotations.UrlAttribute";
+	internal const string ValidationAttribute = "System.ComponentModel.DataAnnotations.ValidationAttribute";
 }

--- a/src/BB84.SourceGenerators/ValidatorGenerator.cs
+++ b/src/BB84.SourceGenerators/ValidatorGenerator.cs
@@ -188,6 +188,12 @@ public sealed class ValidatorGenerator : IIncrementalGenerator
 			case ValidationKind.Compare:
 				AppendCompareValidation(sb, propertyName, rule);
 				break;
+			case ValidationKind.AllowedValues:
+				AppendAllowedValuesValidation(sb, propertyName, rule);
+				break;
+			case ValidationKind.DeniedValues:
+				AppendDeniedValuesValidation(sb, propertyName, rule);
+				break;
 			case ValidationKind.CustomValidation:
 				AppendCustomValidation(sb, propertyName, rule);
 				break;
@@ -309,6 +315,24 @@ public sealed class ValidatorGenerator : IIncrementalGenerator
 		AppendAddError(sb, propertyName, message);
 	}
 
+	private static void AppendAllowedValuesValidation(SourceBuilder sb, string propertyName, ValidationRule rule)
+	{
+		string message = rule.ErrorMessage ?? $"The field {propertyName} does not contain an allowed value.";
+		string conditions = string.Join(" && ", rule.Values!.Value.Select(v => $"!Equals({propertyName}, {v})"));
+
+		sb.AppendLine($"if ({conditions})");
+		AppendAddError(sb, propertyName, message);
+	}
+
+	private static void AppendDeniedValuesValidation(SourceBuilder sb, string propertyName, ValidationRule rule)
+	{
+		string message = rule.ErrorMessage ?? $"The field {propertyName} contains a denied value.";
+		string conditions = string.Join(" || ", rule.Values!.Value.Select(v => $"Equals({propertyName}, {v})"));
+
+		sb.AppendLine($"if ({conditions})");
+		AppendAddError(sb, propertyName, message);
+	}
+
 	private static void AppendCustomValidation(SourceBuilder sb, string propertyName, ValidationRule rule)
 	{
 		string attributeTypeName = rule.CustomAttributeTypeName!;
@@ -361,6 +385,8 @@ public sealed class ValidatorGenerator : IIncrementalGenerator
 					DataAnnotationNames.Phone => ParseSimpleAttribute(attribute, ValidationKind.Phone),
 					DataAnnotationNames.CreditCard => ParseSimpleAttribute(attribute, ValidationKind.CreditCard),
 					DataAnnotationNames.Compare => ParseCompareAttribute(attribute),
+					DataAnnotationNames.AllowedValues => ParseAllowedValuesAttribute(attribute),
+					DataAnnotationNames.DeniedValues => ParseDeniedValuesAttribute(attribute),
 					_ => TryParseCustomValidationAttribute(attribute)
 				};
 
@@ -499,6 +525,60 @@ public sealed class ValidatorGenerator : IIncrementalGenerator
 		return new ValidationRule(ValidationKind.Compare) { CompareProperty = otherProperty, ErrorMessage = errorMessage };
 	}
 
+	private static ValidationRule? ParseAllowedValuesAttribute(AttributeData attribute)
+	{
+		ImmutableArray<TypedConstant> args = attribute.ConstructorArguments;
+
+		if (args.Length < 1 || args[0].Kind != TypedConstantKind.Array)
+			return null;
+
+		ImmutableArray<string> values = [.. args[0].Values
+			.Select(FormatConstantValue)
+			.Where(v => v is not null)
+			.Select(v => v!)];
+
+		if (values.IsEmpty)
+			return null;
+
+		string? errorMessage = GetNamedArgumentValue<string>(attribute, "ErrorMessage");
+
+		return new ValidationRule(ValidationKind.AllowedValues) { Values = values, ErrorMessage = errorMessage };
+	}
+
+	private static ValidationRule? ParseDeniedValuesAttribute(AttributeData attribute)
+	{
+		ImmutableArray<TypedConstant> args = attribute.ConstructorArguments;
+
+		if (args.Length < 1 || args[0].Kind != TypedConstantKind.Array)
+			return null;
+
+		ImmutableArray<string> values = [.. args[0].Values
+			.Select(FormatConstantValue)
+			.Where(v => v is not null)
+			.Select(v => v!)];
+
+		if (values.IsEmpty)
+			return null;
+
+		string? errorMessage = GetNamedArgumentValue<string>(attribute, "ErrorMessage");
+
+		return new ValidationRule(ValidationKind.DeniedValues) { Values = values, ErrorMessage = errorMessage };
+	}
+
+	private static string? FormatConstantValue(TypedConstant constant)
+	{
+		if (constant.IsNull)
+			return "null";
+
+		return constant.Value switch
+		{
+			string str => $"\"{GeneratorHelpers.EscapeString(str)}\"",
+			char c => $"'{c}'",
+			bool b => b ? "true" : "false",
+			_ => constant.Value?.ToString()
+		};
+	}
+
 	private static ValidationRule? TryParseCustomValidationAttribute(AttributeData attribute)
 	{
 		if (attribute.AttributeClass is null)
@@ -580,6 +660,8 @@ public sealed class ValidatorGenerator : IIncrementalGenerator
 		Phone,
 		CreditCard,
 		Compare,
+		AllowedValues,
+		DeniedValues,
 		CustomValidation
 	}
 
@@ -592,6 +674,7 @@ public sealed class ValidatorGenerator : IIncrementalGenerator
 		public string? ErrorMessage { get; set; }
 		public string? CompareProperty { get; set; }
 		public string? CustomAttributeTypeName { get; set; }
+		public ImmutableArray<string>? Values { get; set; }
 	}
 
 	private readonly struct PropertyValidationInfo(string name, string typeName, bool isCollection, bool isArray, ImmutableArray<ValidatorGenerator.ValidationRule> rules)

--- a/tests/BB84.SourceGenerators.Tests/ValidatorGeneratorTests.cs
+++ b/tests/BB84.SourceGenerators.Tests/ValidatorGeneratorTests.cs
@@ -649,6 +649,95 @@ public sealed class ValidatorGeneratorTests
 
 		Assert.IsEmpty(errors);
 	}
+
+#if NET8_0_OR_GREATER
+	[TestMethod]
+	public void ValidateShouldPassAllowedValuesWhenValueInList()
+	{
+		ValidatorAllowedValuesTestModel model = new() { Status = "foo", Code = 2 };
+
+		Dictionary<string, List<string>> errors = model.Validate();
+
+		Assert.IsFalse(errors.ContainsKey("Status"));
+		Assert.IsFalse(errors.ContainsKey("Code"));
+	}
+
+	[TestMethod]
+	public void ValidateShouldDetectAllowedValuesViolationForString()
+	{
+		ValidatorAllowedValuesTestModel model = new() { Status = "unknown", Code = 1 };
+
+		Dictionary<string, List<string>> errors = model.Validate();
+
+		Assert.IsTrue(errors.ContainsKey("Status"));
+		Assert.IsFalse(errors.ContainsKey("Code"));
+	}
+
+	[TestMethod]
+	public void ValidateShouldDetectAllowedValuesViolationForInt()
+	{
+		ValidatorAllowedValuesTestModel model = new() { Status = "bar", Code = 99 };
+
+		Dictionary<string, List<string>> errors = model.Validate();
+
+		Assert.IsFalse(errors.ContainsKey("Status"));
+		Assert.IsTrue(errors.ContainsKey("Code"));
+	}
+
+	[TestMethod]
+	public void ValidateShouldAllowNullForAllowedValuesWhenNullNotInList()
+	{
+		ValidatorAllowedValuesTestModel model = new() { Status = null, Code = 1 };
+
+		Dictionary<string, List<string>> errors = model.Validate();
+
+		Assert.IsTrue(errors.ContainsKey("Status"));
+	}
+
+	[TestMethod]
+	public void ValidateShouldPassDeniedValuesWhenValueNotInList()
+	{
+		ValidatorDeniedValuesTestModel model = new() { Username = "alice", Level = 5 };
+
+		Dictionary<string, List<string>> errors = model.Validate();
+
+		Assert.IsFalse(errors.ContainsKey("Username"));
+		Assert.IsFalse(errors.ContainsKey("Level"));
+	}
+
+	[TestMethod]
+	public void ValidateShouldDetectDeniedValuesViolationForString()
+	{
+		ValidatorDeniedValuesTestModel model = new() { Username = "admin", Level = 5 };
+
+		Dictionary<string, List<string>> errors = model.Validate();
+
+		Assert.IsTrue(errors.ContainsKey("Username"));
+		Assert.IsFalse(errors.ContainsKey("Level"));
+	}
+
+	[TestMethod]
+	public void ValidateShouldDetectDeniedValuesViolationForInt()
+	{
+		ValidatorDeniedValuesTestModel model = new() { Username = "alice", Level = 0 };
+
+		Dictionary<string, List<string>> errors = model.Validate();
+
+		Assert.IsFalse(errors.ContainsKey("Username"));
+		Assert.IsTrue(errors.ContainsKey("Level"));
+	}
+
+	[TestMethod]
+	public void ValidateShouldUseCustomErrorMessageForAllowedValues()
+	{
+		ValidatorAllowedValuesCustomMessageTestModel model = new() { Status = "pending" };
+
+		Dictionary<string, List<string>> errors = model.Validate();
+
+		Assert.IsTrue(errors.ContainsKey("Status"));
+		Assert.IsTrue(errors["Status"].Exists(e => e == "Status must be active or inactive."));
+	}
+#endif
 }
 
 [GenerateValidator]
@@ -758,3 +847,32 @@ public partial class ValidatorValidatableObjectTestModel : IValidatableObject
 			yield return new ValidationResult("End must be after Start.", [nameof(End)]);
 	}
 }
+
+#if NET8_0_OR_GREATER
+[GenerateValidator]
+public partial class ValidatorAllowedValuesTestModel
+{
+	[AllowedValues("foo", "bar", "baz")]
+	public string? Status { get; set; }
+
+	[AllowedValues(1, 2, 3)]
+	public int Code { get; set; }
+}
+
+[GenerateValidator]
+public partial class ValidatorDeniedValuesTestModel
+{
+	[DeniedValues("admin", "root")]
+	public string? Username { get; set; }
+
+	[DeniedValues(0, -1)]
+	public int Level { get; set; }
+}
+
+[GenerateValidator]
+public partial class ValidatorAllowedValuesCustomMessageTestModel
+{
+	[AllowedValues("active", "inactive", ErrorMessage = "Status must be active or inactive.")]
+	public string? Status { get; set; }
+}
+#endif


### PR DESCRIPTION
**Changes:**

- Added support for .NET 8+ `[AllowedValues]` and `[DeniedValues]` attributes in the source generator for inline membership/exclusion validation.
- Extended generator logic and attribute lists.
- Added comprehensive unit tests for allowed/denied values, including custom error messages and null handling.
- Updated documentation and examples in `README.md`.

closes #159 