### PR TITLE
feat(inifile): add `ReadAsync(filePath)` method and update docs/tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ The generator creates the following methods on the decorated class:
 - `Read(string content)` - Static method that parses an INI file string and returns a deserialized instance
 - `TryRead(string content, out T? result)` - Static method that attempts to parse an INI file string, returning `true` on success or `false` on failure without throwing exceptions
 - `Write(TClass instance)` - Static method that serializes an instance into an INI file string
+- `ReadAsync(string filePath)` - Static async method that reads a file line-by-line via `ReadLineAsync` and deserializes INI content; truly non-blocking I/O
 - `ReadAsync(TextReader reader)` - Static async method that reads and deserializes INI content from a `TextReader`
 - `ReadAsync(Stream stream)` - Static async method that reads and deserializes INI content from a `Stream`
 - `WriteAsync(TClass instance, TextWriter writer)` - Static async method that serializes an instance and writes it to a `TextWriter`
@@ -421,9 +422,12 @@ else
     Console.WriteLine("Failed to parse INI content");
 }
 
+// Async reading from a file path (line-by-line, truly non-blocking)
+AppConfig asyncConfig = await AppConfig.ReadAsync("config.ini");
+
 // Async reading from a stream
 using FileStream fs = File.OpenRead("config.ini");
-AppConfig asyncConfig = await AppConfig.ReadAsync(fs);
+AppConfig asyncConfigFromStream = await AppConfig.ReadAsync(fs);
 
 // Async writing to a stream
 using FileStream outFs = File.Create("output.ini");
@@ -1913,7 +1917,7 @@ The generated enum extension methods provide significant performance improvement
 - Uses `CultureInfo.InvariantCulture` for consistent cross-platform formatting
 - Supports `Guid`, `TimeSpan`, `DateTimeOffset`, and collection types (`List<T>`, `T[]`)
 - Provides `TryRead` for safe parsing without exceptions
-- Provides async `ReadAsync`/`WriteAsync` for non-blocking I/O with `Stream` and `TextReader`/`TextWriter`
+- Provides async `ReadAsync`/`WriteAsync` for non-blocking I/O with file path (line-by-line via `ReadLineAsync`), `Stream`, and `TextReader`/`TextWriter`
 
 ### Builder Pattern
 

--- a/src/BB84.SourceGenerators/IniFileGenerator.cs
+++ b/src/BB84.SourceGenerators/IniFileGenerator.cs
@@ -218,6 +218,40 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 	private static void AppendReadAsyncMethod(SourceBuilder sb, string className)
 	{
 		sb.AppendLine();
+		sb.AppendLine("#if NET5_0_OR_GREATER");
+		sb.AppendLine("/// <summary>");
+		sb.AppendLine($"/// Asynchronously reads INI file content from the specified file and deserializes it");
+		sb.AppendLine($"/// into a new instance of <see cref=\"{className}\"/>.");
+		sb.AppendLine("/// </summary>");
+		sb.AppendLine("/// <param name=\"filePath\">The path to the INI file to read.</param>");
+		sb.AppendLine("/// <param name=\"cancellationToken\">A cancellation token that can be used to cancel the asynchronous operation.</param>");
+		sb.AppendLine($"/// <returns>A task representing the asynchronous operation, containing the deserialized <see cref=\"{className}\"/> instance.</returns>");
+		sb.AppendLine($"public static async Task<{className}> ReadAsync(string filePath, CancellationToken cancellationToken = default)");
+		sb.AppendLine("#else");
+		sb.AppendLine("/// <summary>");
+		sb.AppendLine($"/// Asynchronously reads INI file content from the specified file and deserializes it");
+		sb.AppendLine($"/// into a new instance of <see cref=\"{className}\"/>.");
+		sb.AppendLine("/// </summary>");
+		sb.AppendLine("/// <param name=\"filePath\">The path to the INI file to read.</param>");
+		sb.AppendLine($"/// <returns>A task representing the asynchronous operation, containing the deserialized <see cref=\"{className}\"/> instance.</returns>");
+		sb.AppendLine($"public static async Task<{className}> ReadAsync(string filePath)");
+		sb.AppendLine("#endif");
+		sb.OpenBrace();
+		sb.AppendLine("using StreamReader reader = new StreamReader(filePath, Encoding.UTF8);");
+		sb.AppendLine("StringBuilder sb = new StringBuilder();");
+		sb.AppendLine("string? line;");
+		sb.AppendLine("#if NET5_0_OR_GREATER");
+		sb.AppendLine("while ((line = await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false)) != null)");
+		sb.AppendLine("#else");
+		sb.AppendLine("while ((line = await reader.ReadLineAsync().ConfigureAwait(false)) != null)");
+		sb.AppendLine("#endif");
+		sb.Indent();
+		sb.AppendLine("sb.AppendLine(line);");
+		sb.Outdent();
+		sb.AppendLine("return Read(sb.ToString());");
+		sb.CloseBrace();
+		sb.AppendLine();
+		sb.AppendLine("#if NET5_0_OR_GREATER");
 		sb.AppendLine("/// <summary>");
 		sb.AppendLine($"/// Asynchronously reads INI file content from the specified <see cref=\"TextReader\"/> and deserializes it");
 		sb.AppendLine($"/// into a new instance of <see cref=\"{className}\"/>.");
@@ -225,9 +259,14 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 		sb.AppendLine("/// <param name=\"reader\">The <see cref=\"TextReader\"/> to read from.</param>");
 		sb.AppendLine("/// <param name=\"cancellationToken\">A cancellation token that can be used to cancel the asynchronous operation.</param>");
 		sb.AppendLine($"/// <returns>A task representing the asynchronous operation, containing the deserialized <see cref=\"{className}\"/> instance.</returns>");
-		sb.AppendLine("#if NET5_0_OR_GREATER");
 		sb.AppendLine($"public static async Task<{className}> ReadAsync(TextReader reader, CancellationToken cancellationToken = default)");
 		sb.AppendLine("#else");
+		sb.AppendLine("/// <summary>");
+		sb.AppendLine($"/// Asynchronously reads INI file content from the specified <see cref=\"TextReader\"/> and deserializes it");
+		sb.AppendLine($"/// into a new instance of <see cref=\"{className}\"/>.");
+		sb.AppendLine("/// </summary>");
+		sb.AppendLine("/// <param name=\"reader\">The <see cref=\"TextReader\"/> to read from.</param>");
+		sb.AppendLine($"/// <returns>A task representing the asynchronous operation, containing the deserialized <see cref=\"{className}\"/> instance.</returns>");
 		sb.AppendLine($"public static async Task<{className}> ReadAsync(TextReader reader)");
 		sb.AppendLine("#endif");
 		sb.OpenBrace();
@@ -239,6 +278,7 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 		sb.AppendLine("return Read(content);");
 		sb.CloseBrace();
 		sb.AppendLine();
+		sb.AppendLine("#if NET5_0_OR_GREATER");
 		sb.AppendLine("/// <summary>");
 		sb.AppendLine($"/// Asynchronously reads INI file content from the specified <see cref=\"Stream\"/> and deserializes it");
 		sb.AppendLine($"/// into a new instance of <see cref=\"{className}\"/>.");
@@ -246,9 +286,14 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 		sb.AppendLine("/// <param name=\"stream\">The <see cref=\"Stream\"/> to read from.</param>");
 		sb.AppendLine("/// <param name=\"cancellationToken\">A cancellation token that can be used to cancel the asynchronous operation.</param>");
 		sb.AppendLine($"/// <returns>A task representing the asynchronous operation, containing the deserialized <see cref=\"{className}\"/> instance.</returns>");
-		sb.AppendLine("#if NET5_0_OR_GREATER");
 		sb.AppendLine($"public static async Task<{className}> ReadAsync(Stream stream, CancellationToken cancellationToken = default)");
 		sb.AppendLine("#else");
+		sb.AppendLine("/// <summary>");
+		sb.AppendLine($"/// Asynchronously reads INI file content from the specified <see cref=\"Stream\"/> and deserializes it");
+		sb.AppendLine($"/// into a new instance of <see cref=\"{className}\"/>.");
+		sb.AppendLine("/// </summary>");
+		sb.AppendLine("/// <param name=\"stream\">The <see cref=\"Stream\"/> to read from.</param>");
+		sb.AppendLine($"/// <returns>A task representing the asynchronous operation, containing the deserialized <see cref=\"{className}\"/> instance.</returns>");
 		sb.AppendLine($"public static async Task<{className}> ReadAsync(Stream stream)");
 		sb.AppendLine("#endif");
 		sb.OpenBrace();
@@ -264,6 +309,7 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 	private static void AppendWriteAsyncMethod(SourceBuilder sb, string className)
 	{
 		sb.AppendLine();
+		sb.AppendLine("#if NET5_0_OR_GREATER");
 		sb.AppendLine("/// <summary>");
 		sb.AppendLine($"/// Asynchronously writes the specified <see cref=\"{className}\"/> instance to the specified <see cref=\"TextWriter\"/>.");
 		sb.AppendLine("/// </summary>");
@@ -271,9 +317,14 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 		sb.AppendLine("/// <param name=\"writer\">The <see cref=\"TextWriter\"/> to write to.</param>");
 		sb.AppendLine("/// <param name=\"cancellationToken\">A cancellation token that can be used to cancel the asynchronous operation.</param>");
 		sb.AppendLine("/// <returns>A task representing the asynchronous operation.</returns>");
-		sb.AppendLine("#if NET5_0_OR_GREATER");
 		sb.AppendLine($"public static async Task WriteAsync({className} instance, TextWriter writer, CancellationToken cancellationToken = default)");
 		sb.AppendLine("#else");
+		sb.AppendLine("/// <summary>");
+		sb.AppendLine($"/// Asynchronously writes the specified <see cref=\"{className}\"/> instance to the specified <see cref=\"TextWriter\"/>.");
+		sb.AppendLine("/// </summary>");
+		sb.AppendLine($"/// <param name=\"instance\">The <see cref=\"{className}\"/> instance to serialize.</param>");
+		sb.AppendLine("/// <param name=\"writer\">The <see cref=\"TextWriter\"/> to write to.</param>");
+		sb.AppendLine("/// <returns>A task representing the asynchronous operation.</returns>");
 		sb.AppendLine($"public static async Task WriteAsync({className} instance, TextWriter writer)");
 		sb.AppendLine("#endif");
 		sb.OpenBrace();
@@ -286,6 +337,7 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 		sb.AppendLine("#endif");
 		sb.CloseBrace();
 		sb.AppendLine();
+		sb.AppendLine("#if NET5_0_OR_GREATER");
 		sb.AppendLine("/// <summary>");
 		sb.AppendLine($"/// Asynchronously writes the specified <see cref=\"{className}\"/> instance to the specified <see cref=\"Stream\"/>.");
 		sb.AppendLine("/// </summary>");
@@ -293,9 +345,14 @@ public sealed class IniFileGenerator : IIncrementalGenerator
 		sb.AppendLine("/// <param name=\"stream\">The <see cref=\"Stream\"/> to write to.</param>");
 		sb.AppendLine("/// <param name=\"cancellationToken\">A cancellation token that can be used to cancel the asynchronous operation.</param>");
 		sb.AppendLine("/// <returns>A task representing the asynchronous operation.</returns>");
-		sb.AppendLine("#if NET5_0_OR_GREATER");
 		sb.AppendLine($"public static async Task WriteAsync({className} instance, Stream stream, CancellationToken cancellationToken = default)");
 		sb.AppendLine("#else");
+		sb.AppendLine("/// <summary>");
+		sb.AppendLine($"/// Asynchronously writes the specified <see cref=\"{className}\"/> instance to the specified <see cref=\"Stream\"/>.");
+		sb.AppendLine("/// </summary>");
+		sb.AppendLine($"/// <param name=\"instance\">The <see cref=\"{className}\"/> instance to serialize.</param>");
+		sb.AppendLine("/// <param name=\"stream\">The <see cref=\"Stream\"/> to write to.</param>");
+		sb.AppendLine("/// <returns>A task representing the asynchronous operation.</returns>");
 		sb.AppendLine($"public static async Task WriteAsync({className} instance, Stream stream)");
 		sb.AppendLine("#endif");
 		sb.OpenBrace();

--- a/tests/BB84.SourceGenerators.Tests/IniFileGeneratorTests.cs
+++ b/tests/BB84.SourceGenerators.Tests/IniFileGeneratorTests.cs
@@ -937,6 +937,36 @@ public sealed class IniFileGeneratorTests
 		Assert.Contains("[General]", result);
 		Assert.Contains("AppName=StreamWrite", result);
 	}
+
+	[TestMethod]
+	public async Task ReadAsyncShouldDeserializeFromFilePath()
+	{
+		string content = "[General]\r\nAppName=FileApp\r\nVersion=11\r\nEnabled=True\r\n";
+		string filePath = Path.GetTempFileName();
+		try
+		{
+			File.WriteAllText(filePath, content, Encoding.UTF8);
+
+#if NET5_0_OR_GREATER
+			TestIniFile result = await TestIniFile
+				.ReadAsync(filePath, _testToken)
+				.ConfigureAwait(false);
+#else
+			TestIniFile result = await TestIniFile
+				.ReadAsync(filePath)
+				.ConfigureAwait(false);
+#endif
+
+			Assert.IsNotNull(result.General);
+			Assert.AreEqual("FileApp", result.General.AppName);
+			Assert.AreEqual(11, result.General.Version);
+			Assert.IsTrue(result.General.Enabled);
+		}
+		finally
+		{
+			File.Delete(filePath);
+		}
+	}
 }
 
 #region Test Types


### PR DESCRIPTION
**Changes:**

- Added a static async `ReadAsync(string filePath)` method for INI file deserialization from file paths.
- Improved async method documentation and clarified usage for file, stream, and reader scenarios.
- Added a unit test for file path deserialization.
- Updated `README.md` with usage examples and feature lists.

closes #162