### PR TITLE
feat(sourcebuilder): add `SourceBuilder` struct/record APIs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -2025,6 +2025,30 @@ Source generators run during compilation and generate additional C# source files
 - **Debuggable** - You can step through generated code during debugging
 - **No reflection** - Generated code uses direct method calls
 
+## Developer Reference
+
+### SourceBuilder
+
+`SourceBuilder` is an internal helper used by all generators to emit indented C# source text. Each `Open*` method appends the declaration line and a `{`, increments the indent level, and returns `this` for chaining. Each `Close*` method is a semantic alias for `CloseBrace()`.
+
+| Method                                                 | Emitted declaration                                  |
+| ------------------------------------------------------ | ---------------------------------------------------- |
+| `OpenNamespace("My.NS")`                               | `namespace My.NS`                                    |
+| `OpenClass("public", "Foo")`                           | `public partial class Foo`                           |
+| `OpenClass("public", "Foo", "IDisposable")`            | `public partial class Foo : IDisposable`             |
+| `OpenSealedClass("public", "Foo")`                     | `public sealed class Foo`                            |
+| `OpenSealedClass("public", "Foo", "IDisposable")`      | `public sealed class Foo : IDisposable`              |
+| `OpenStruct("public", "Foo")`                          | `public partial struct Foo`                          |
+| `OpenStruct("public", "Foo", "IEquatable<Foo>")`       | `public partial struct Foo : IEquatable<Foo>`        |
+| `OpenRecord("public", "Bar")`                          | `public partial record Bar`                          |
+| `OpenRecord("public", "Bar", "IDisposable")`           | `public partial record Bar : IDisposable`            |
+| `OpenSealedRecord("public", "Bar")`                    | `public sealed partial record Bar`                   |
+| `OpenSealedRecord("public", "Bar", "BaseRecord")`      | `public sealed partial record Bar : BaseRecord`      |
+| `OpenRecordStruct("public", "Baz")`                    | `public partial record struct Baz`                   |
+| `OpenRecordStruct("public", "Baz", "IEquatable<Baz>")` | `public partial record struct Baz : IEquatable<Baz>` |
+
+Close methods: `CloseNamespace()`, `CloseClass()`, `CloseStruct()`, `CloseRecord()`, `CloseRecordStruct()` — all delegate to `CloseBrace()`.
+
 ## Contributing
 
 Contributions are welcome! If you have an idea for a new feature, improvement, or bug fix, please follow these steps:

--- a/src/BB84.SourceGenerators/BB84.SourceGenerators.csproj
+++ b/src/BB84.SourceGenerators/BB84.SourceGenerators.csproj
@@ -14,6 +14,7 @@
 		<SuppressDependenciesWhenPacking>True</SuppressDependenciesWhenPacking>
 		<TargetFramework>netstandard2.0</TargetFramework>
 	</PropertyGroup>
+
 	<ItemGroup>
 		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers">
 			<PrivateAssets>all</PrivateAssets>
@@ -59,5 +60,8 @@
 	<ItemGroup>
 		<!-- Packs the generator DLL into the analyzers folder so Roslyn loads it as a source generator -->
 		<None Include="$(OutputPath)\$(AssemblyName).dll" Pack="True" PackagePath="analyzers/dotnet/cs" Visible="False" />
+	</ItemGroup>
+	<ItemGroup>
+		<InternalsVisibleTo Include="$(AssemblyName).Tests" />
 	</ItemGroup>
 </Project>

--- a/src/BB84.SourceGenerators/CloneableGenerator.cs
+++ b/src/BB84.SourceGenerators/CloneableGenerator.cs
@@ -152,8 +152,7 @@ public sealed class CloneableGenerator : IIncrementalGenerator
 
 	private static void AppendPartialStruct(SourceBuilder sb, string structName, string accessibility, ImmutableArray<PropertyDescriptor> properties)
 	{
-		sb.AppendLine($"{accessibility} partial struct {structName} : ICloneable");
-		sb.OpenBrace();
+		sb.OpenStruct(accessibility, structName, "ICloneable");
 
 		AppendCloneMethod(sb, structName, properties, isStruct: true);
 		sb.AppendLine();
@@ -161,7 +160,7 @@ public sealed class CloneableGenerator : IIncrementalGenerator
 		sb.AppendLine();
 		AppendICloneableClone(sb);
 
-		sb.CloseBrace();
+		sb.CloseStruct();
 	}
 
 	private static void AppendCloneMethod(SourceBuilder sb, string typeName, ImmutableArray<PropertyDescriptor> properties, bool isStruct)

--- a/src/BB84.SourceGenerators/Helpers/SourceBuilder.cs
+++ b/src/BB84.SourceGenerators/Helpers/SourceBuilder.cs
@@ -138,10 +138,15 @@ internal sealed class SourceBuilder
 	/// </summary>
 	/// <param name="accessibility">The accessibility modifier.</param>
 	/// <param name="className">The class name.</param>
+	/// <param name="baseTypes">Optional base types / interfaces to implement.</param>
 	/// <returns>The current <see cref="SourceBuilder"/> instance.</returns>
-	public SourceBuilder OpenSealedClass(string accessibility, string className)
+	public SourceBuilder OpenSealedClass(string accessibility, string className, string? baseTypes = null)
 	{
-		AppendLine($"{accessibility} sealed class {className}");
+		if (baseTypes is not null)
+			AppendLine($"{accessibility} sealed class {className} : {baseTypes}");
+		else
+			AppendLine($"{accessibility} sealed class {className}");
+
 		OpenBrace();
 		return this;
 	}
@@ -151,6 +156,108 @@ internal sealed class SourceBuilder
 	/// </summary>
 	/// <returns>The current <see cref="SourceBuilder"/> instance.</returns>
 	public SourceBuilder CloseClass()
+	{
+		CloseBrace();
+		return this;
+	}
+
+	/// <summary>
+	/// Opens a struct declaration.
+	/// </summary>
+	/// <param name="accessibility">The accessibility modifier.</param>
+	/// <param name="structName">The struct name.</param>
+	/// <param name="baseTypes">Optional base types / interfaces to implement.</param>
+	/// <returns>The current <see cref="SourceBuilder"/> instance.</returns>
+	public SourceBuilder OpenStruct(string accessibility, string structName, string? baseTypes = null)
+	{
+		if (baseTypes is not null)
+			AppendLine($"{accessibility} partial struct {structName} : {baseTypes}");
+		else
+			AppendLine($"{accessibility} partial struct {structName}");
+
+		OpenBrace();
+		return this;
+	}
+
+	/// <summary>
+	/// Closes the current struct block.
+	/// </summary>
+	/// <returns>The current <see cref="SourceBuilder"/> instance.</returns>
+	public SourceBuilder CloseStruct()
+	{
+		CloseBrace();
+		return this;
+	}
+
+	/// <summary>
+	/// Opens a record declaration.
+	/// </summary>
+	/// <param name="accessibility">The accessibility modifier.</param>
+	/// <param name="recordName">The record name.</param>
+	/// <param name="baseTypes">Optional base types / interfaces to implement.</param>
+	/// <returns>The current <see cref="SourceBuilder"/> instance.</returns>
+	public SourceBuilder OpenRecord(string accessibility, string recordName, string? baseTypes = null)
+	{
+		if (baseTypes is not null)
+			AppendLine($"{accessibility} partial record {recordName} : {baseTypes}");
+		else
+			AppendLine($"{accessibility} partial record {recordName}");
+
+		OpenBrace();
+		return this;
+	}
+
+	/// <summary>
+	/// Opens a sealed record declaration.
+	/// </summary>
+	/// <param name="accessibility">The accessibility modifier.</param>
+	/// <param name="recordName">The record name.</param>
+	/// <param name="baseTypes">Optional base types / interfaces to implement.</param>
+	/// <returns>The current <see cref="SourceBuilder"/> instance.</returns>
+	public SourceBuilder OpenSealedRecord(string accessibility, string recordName, string? baseTypes = null)
+	{
+		if (baseTypes is not null)
+			AppendLine($"{accessibility} sealed partial record {recordName} : {baseTypes}");
+		else
+			AppendLine($"{accessibility} sealed partial record {recordName}");
+
+		OpenBrace();
+		return this;
+	}
+
+	/// <summary>
+	/// Closes the current record block.
+	/// </summary>
+	/// <returns>The current <see cref="SourceBuilder"/> instance.</returns>
+	public SourceBuilder CloseRecord()
+	{
+		CloseBrace();
+		return this;
+	}
+
+	/// <summary>
+	/// Opens a record struct declaration.
+	/// </summary>
+	/// <param name="accessibility">The accessibility modifier.</param>
+	/// <param name="recordStructName">The record struct name.</param>
+	/// <param name="baseTypes">Optional base types / interfaces to implement.</param>
+	/// <returns>The current <see cref="SourceBuilder"/> instance.</returns>
+	public SourceBuilder OpenRecordStruct(string accessibility, string recordStructName, string? baseTypes = null)
+	{
+		if (baseTypes is not null)
+			AppendLine($"{accessibility} partial record struct {recordStructName} : {baseTypes}");
+		else
+			AppendLine($"{accessibility} partial record struct {recordStructName}");
+
+		OpenBrace();
+		return this;
+	}
+
+	/// <summary>
+	/// Closes the current record struct block.
+	/// </summary>
+	/// <returns>The current <see cref="SourceBuilder"/> instance.</returns>
+	public SourceBuilder CloseRecordStruct()
 	{
 		CloseBrace();
 		return this;

--- a/tests/BB84.SourceGenerators.Tests/BB84.SourceGenerators.Tests.csproj
+++ b/tests/BB84.SourceGenerators.Tests/BB84.SourceGenerators.Tests.csproj
@@ -4,7 +4,7 @@
 		<EmitCompilerGeneratedFiles>True</EmitCompilerGeneratedFiles>
 		<IsPackable>False</IsPackable>
 		<IsTestProject>True</IsTestProject>
-		<NoWarn>$(NoWarn);CA1859;CS1591;CA1711;CA1816</NoWarn>
+		<NoWarn>$(NoWarn);CA1859;CS1591;CA1711;CA1816;CS0436</NoWarn>
 		<TargetFrameworks>net472;net48;net8.0;net10.0</TargetFrameworks>
 	</PropertyGroup>
 	<ItemGroup>

--- a/tests/BB84.SourceGenerators.Tests/Helpers/SourceBuilderTests.cs
+++ b/tests/BB84.SourceGenerators.Tests/Helpers/SourceBuilderTests.cs
@@ -1,0 +1,198 @@
+// Copyright: 2026 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+using BB84.SourceGenerators.Helpers;
+
+namespace BB84.SourceGenerators.Tests.Helpers;
+
+[TestClass]
+public sealed class SourceBuilderTests
+{
+	[TestMethod]
+	public void OpenClassWithoutBaseTypesEmitsPartialClassDeclaration()
+	{
+		SourceBuilder sb = new();
+		sb.OpenClass("public", "Foo");
+		sb.CloseClass();
+
+		string result = sb.ToString();
+
+		Assert.Contains("public partial class Foo", result);
+		Assert.DoesNotContain(':', result);
+	}
+
+	[TestMethod]
+	public void OpenClassWithBaseTypesEmitsPartialClassDeclarationWithBaseTypes()
+	{
+		SourceBuilder sb = new();
+		sb.OpenClass("public", "Foo", "IDisposable");
+		sb.CloseClass();
+
+		string result = sb.ToString();
+
+		Assert.Contains("public partial class Foo : IDisposable", result);
+	}
+
+	[TestMethod]
+	public void OpenSealedClassWithoutBaseTypesEmitsSealedClassDeclaration()
+	{
+		SourceBuilder sb = new();
+		sb.OpenSealedClass("public", "Foo");
+		sb.CloseClass();
+
+		string result = sb.ToString();
+
+		Assert.Contains("public sealed class Foo", result);
+		Assert.DoesNotContain(':', result);
+	}
+
+	[TestMethod]
+	public void OpenSealedClassWithBaseTypesEmitsSealedClassDeclarationWithBaseTypes()
+	{
+		SourceBuilder sb = new();
+		sb.OpenSealedClass("public", "Foo", "IDisposable");
+		sb.CloseClass();
+
+		string result = sb.ToString();
+
+		Assert.Contains("public sealed class Foo : IDisposable", result);
+	}
+
+	[TestMethod]
+	public void OpenStructWithoutBaseTypesEmitsPartialStructDeclaration()
+	{
+		SourceBuilder sb = new();
+		sb.OpenStruct("public", "Foo");
+		sb.CloseStruct();
+
+		string result = sb.ToString();
+
+		Assert.Contains("public partial struct Foo", result);
+		Assert.DoesNotContain(':', result);
+	}
+
+	[TestMethod]
+	public void OpenStructWithBaseTypesEmitsPartialStructDeclarationWithBaseTypes()
+	{
+		SourceBuilder sb = new();
+		sb.OpenStruct("public", "Foo", "IEquatable<Foo>");
+		sb.CloseStruct();
+
+		string result = sb.ToString();
+
+		Assert.Contains("public partial struct Foo : IEquatable<Foo>", result);
+	}
+
+	[TestMethod]
+	public void OpenRecordWithoutBaseTypesEmitsPartialRecordDeclaration()
+	{
+		SourceBuilder sb = new();
+		sb.OpenRecord("public", "Bar");
+		sb.CloseRecord();
+
+		string result = sb.ToString();
+
+		Assert.Contains("public partial record Bar", result);
+		Assert.DoesNotContain(':', result);
+	}
+
+	[TestMethod]
+	public void OpenRecordWithBaseTypesEmitsPartialRecordDeclarationWithBaseTypes()
+	{
+		SourceBuilder sb = new();
+		sb.OpenRecord("public", "Bar", "IDisposable");
+		sb.CloseRecord();
+
+		string result = sb.ToString();
+
+		Assert.Contains("public partial record Bar : IDisposable", result);
+	}
+
+	[TestMethod]
+	public void OpenSealedRecordWithoutBaseTypesEmitsSealedPartialRecordDeclaration()
+	{
+		SourceBuilder sb = new();
+		sb.OpenSealedRecord("public", "Bar");
+		sb.CloseRecord();
+
+		string result = sb.ToString();
+
+		Assert.Contains("public sealed partial record Bar", result);
+		Assert.DoesNotContain(':', result);
+	}
+
+	[TestMethod]
+	public void OpenSealedRecordWithBaseTypesEmitsSealedPartialRecordDeclarationWithBaseTypes()
+	{
+		SourceBuilder sb = new();
+		sb.OpenSealedRecord("public", "Bar", "BaseRecord");
+		sb.CloseRecord();
+
+		string result = sb.ToString();
+
+		Assert.Contains("public sealed partial record Bar : BaseRecord", result);
+	}
+
+	[TestMethod]
+	public void OpenRecordStructWithoutBaseTypesEmitsPartialRecordStructDeclaration()
+	{
+		SourceBuilder sb = new();
+		sb.OpenRecordStruct("public", "Baz");
+		sb.CloseRecordStruct();
+
+		string result = sb.ToString();
+
+		Assert.Contains("public partial record struct Baz", result);
+		Assert.DoesNotContain(':', result);
+	}
+
+	[TestMethod]
+	public void OpenRecordStructWithBaseTypesEmitsPartialRecordStructDeclarationWithBaseTypes()
+	{
+		SourceBuilder sb = new();
+		sb.OpenRecordStruct("public", "Baz", "IEquatable<Baz>");
+		sb.CloseRecordStruct();
+
+		string result = sb.ToString();
+
+		Assert.Contains("public partial record struct Baz : IEquatable<Baz>", result);
+	}
+
+	[TestMethod]
+	public void OpenStructIncreasesIndentLevel()
+	{
+		SourceBuilder sb = new();
+
+		Assert.AreEqual(0, sb.IndentLevel);
+		sb.OpenStruct("public", "Foo");
+		Assert.AreEqual(1, sb.IndentLevel);
+		sb.CloseStruct();
+		Assert.AreEqual(0, sb.IndentLevel);
+	}
+
+	[TestMethod]
+	public void OpenRecordIncreasesIndentLevel()
+	{
+		SourceBuilder sb = new();
+
+		Assert.AreEqual(0, sb.IndentLevel);
+		sb.OpenRecord("public", "Bar");
+		Assert.AreEqual(1, sb.IndentLevel);
+		sb.CloseRecord();
+		Assert.AreEqual(0, sb.IndentLevel);
+	}
+
+	[TestMethod]
+	public void OpenRecordStructIncreasesIndentLevel()
+	{
+		SourceBuilder sb = new();
+
+		Assert.AreEqual(0, sb.IndentLevel);
+		sb.OpenRecordStruct("public", "Baz");
+		Assert.AreEqual(1, sb.IndentLevel);
+		sb.CloseRecordStruct();
+		Assert.AreEqual(0, sb.IndentLevel);
+	}
+}


### PR DESCRIPTION
**Changes:**

- Expanded `SourceBuilder` with APIs for struct, record, sealed record, and record struct declarations, supporting optional base types.
- Updated `CloneableGenerator` to use these APIs and added `SourceBuilderTests` for coverage.
- Updated project files for analyzers, internals access, and warning suppression and documented the API in `README.md`.

closes #158 